### PR TITLE
Use Uniform Buffer Objects for bones

### DIFF
--- a/Smash Forge/Shader.cs
+++ b/Smash Forge/Shader.cs
@@ -55,12 +55,14 @@ namespace Smash_Forge
             //MessageBox.Show("GL minor: " + GL.GetInteger(GetPName.MinorVersion));
             loadShader(filename, ShaderType.VertexShader, programID, out vsID);
 			GL.LinkProgram (programID);
-		}
+            Console.WriteLine(GL.GetProgramInfoLog(programID));
+        }
 
 		public void fragmentShader(string filename){
 			loadShader(filename, ShaderType.FragmentShader, programID, out fsID);
 			GL.LinkProgram (programID);
-		}
+            Console.WriteLine(GL.GetProgramInfoLog(programID));
+        }
 
         void loadShader(string shader, ShaderType type, int program, out int address)
 		{


### PR DESCRIPTION
Some graphics cards have limited uniform slots available, so a static uniform array can possibly use them all. Update shader code to use UBO for bones array in order to save uniform slots.  Delay shader creation until after bone processing so that array size can be set to the proper size.

- Added output of shader program errors
- Changed bones uniform into UBO to avoid using up more uniform slots than necessary
- Changed vertex shader string to include formatting for bone count value replacement