### PR TITLE
Use Relocation Table to determine valid offsets

### DIFF
--- a/Smash Forge/IO/FileData.cs
+++ b/Smash Forge/IO/FileData.cs
@@ -226,6 +226,34 @@ namespace Smash_Forge
             while (p % i != 0)
                 p++;
         }
-	}
+
+        public void writeInt(int value)
+        {
+            byte[] v = BitConverter.GetBytes(value);
+
+            if (Endian == Endianness.Little)
+            {
+                b[p++] = v[0]; b[p++] = v[1]; b[p++] = v[2]; b[p++] = v[3];
+            }
+            else
+            {
+                b[p++] = v[3]; b[p++] = v[2]; b[p++] = v[1]; b[p++] = v[0];
+            }
+        }
+
+        public void writeInt(int pos, int value)
+        {
+            byte[] v = BitConverter.GetBytes(value);
+
+            if (Endian == Endianness.Little)
+            {
+                b[pos++] = v[0]; b[pos++] = v[1]; b[pos++] = v[2]; b[pos++] = v[3];
+            }
+            else
+            {
+                b[pos++] = v[3]; b[pos++] = v[2]; b[pos++] = v[1]; b[pos++] = v[0];
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
The relocation table should be used to determine which offsets within the DAT file are valid by updating them during header processing with the proper address/offset as there can be relevant data located at the beginning of the data block.

- Added temporary change to FileData to support writing to data buffer (will probably refactor this class at some point in the future)
- Updated DAT logic to update all relocation table offsets appropriately
- Removed all unnecessary references to headerSize/0x20 as an offset
