### PR TITLE
Fix hitbox/hurtbox rendering for joint table bones

### DIFF
--- a/Smash Forge/CharacterParamManager.cs
+++ b/Smash Forge/CharacterParamManager.cs
@@ -45,7 +45,7 @@ namespace Smash_Forge
                 {
                     ECB ecb = new ECB();
                     ecb.ID = id;
-                    ecb.Bone = (Convert.ToInt32(((ParamGroup)param.Groups[3])[id][0].Value) - 1).Clamp(0, int.MaxValue);
+                    ecb.Bone = VBN.applyBoneThunk(Convert.ToInt32(((ParamGroup)param.Groups[3])[id][0].Value));
                     ecb.X = Convert.ToSingle(((ParamGroup)param.Groups[3])[id][1].Value);
                     ecb.Y = Convert.ToSingle(((ParamGroup)param.Groups[3])[id][2].Value);
                     ecb.Z = Convert.ToSingle(((ParamGroup)param.Groups[3])[id][3].Value);
@@ -67,9 +67,16 @@ namespace Smash_Forge
                     hurtbox.Z2 = Convert.ToSingle(((ParamGroup)param.Groups[4])[id][5].Value);
 
                     hurtbox.Size = Convert.ToSingle(((ParamGroup)param.Groups[4])[id][6].Value);
-                    hurtbox.Bone = (Convert.ToInt32(((ParamGroup)param.Groups[4])[id][7].Value) - 1).Clamp(0, int.MaxValue);
+                    hurtbox.Bone = VBN.applyBoneThunk(Convert.ToInt32(((ParamGroup)param.Groups[4])[id][7].Value));
                     hurtbox.Part = Convert.ToInt32(((ParamGroup)param.Groups[4])[id][8].Value);
                     hurtbox.Zone = Convert.ToInt32(((ParamGroup)param.Groups[4])[id][9].Value);
+
+                    if (hurtbox.X == hurtbox.X2 && hurtbox.Y == hurtbox.Y2 && hurtbox.Z == hurtbox.Z2)
+                    {
+                        // It can't be anything but a sphere. I think some part of the param might
+                        // control this so this might be a crude detection method. This fixes Bowser Jr at least.
+                        hurtbox.isSphere = true;
+                    }
 
                     Hurtboxes.Add(id, hurtbox);
                 }
@@ -116,6 +123,7 @@ namespace Smash_Forge
         public float Y2 { get; set; }
         public float Z2 { get; set; }
         public int Zone { get; set; }
+        public bool isSphere { get; set; } = false;
 
         public const int LW_ZONE = 0;
         public const int N_ZONE = 1;

--- a/Smash Forge/GUI/MainForm.cs
+++ b/Smash Forge/GUI/MainForm.cs
@@ -1337,17 +1337,12 @@ namespace Smash_Forge
             {
                 Runtime.TargetVBN = new VBN(filename);
 
-                ModelContainer con = new ModelContainer();
-                con.vbn = Runtime.TargetVBN;
-                Runtime.ModelContainers.Add(con);
-
+                ModelContainer con = resyncTargetVBN();
                 if (Directory.Exists("Skapon\\"))
                 {
                     NUD nud = Skapon.Create(Runtime.TargetVBN);
                     con.nud = nud;
                 }
-
-                resyncTargetVBN();
             }
 
             if (filename.EndsWith(".sb"))
@@ -1387,8 +1382,8 @@ namespace Smash_Forge
                 AddDockedControl(p);
                 //Runtime.TargetVBN = dat.bones;
 
-                resyncTargetVBN();
                 meshList.refresh();
+                resyncTargetVBN();
             }
 
             if (filename.EndsWith(".nut"))
@@ -1592,6 +1587,7 @@ namespace Smash_Forge
             if (filename.EndsWith(".nud"))
             {
                 openNud(filename);
+                resyncTargetVBN();
             }
 
             if (filename.EndsWith(".moi"))
@@ -1628,12 +1624,26 @@ namespace Smash_Forge
             ModelContainer modelContainer = null;
             if (Runtime.TargetVBN != null)
             {
-                modelContainer = new ModelContainer();
-                modelContainer.vbn = Runtime.TargetVBN;
-                Runtime.ModelContainers.Add(modelContainer);
+                // Make sure the TargetVBN is in use *somewhere* in our models
+                bool found = false;
+                foreach (ModelContainer m in Runtime.ModelContainers)
+                {
+                    if (m.vbn.essentialComparison(Runtime.TargetVBN))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    modelContainer = new ModelContainer();
+                    modelContainer.vbn = Runtime.TargetVBN;
+                    Runtime.ModelContainers.Add(modelContainer);
+                }
             }
             else
             {
+                // Fetch the TargetVBN from the first model we come across
                 foreach (ModelContainer m in Runtime.ModelContainers)
                 {
                     if (m.vbn != null)


### PR DESCRIPTION
- Open Character dialogue now syncs, populates and refreshes the bone control.
- Fixed (harmless) memory leak when opening files (new ModelContainer being made each time)
- Added event 0x2F08F54F ("Delete_Catch_Collision" by ID) which is used mainly in tether grabs like ZSS and Link to remove a particular grab box halfway through.
- Fixed bone / joint table indexing between the NUD bones and the joint table bones such that bones from joint tables 1 and above are actually found properly.
- Added hurtbox rendering for circular hurtboxes (see: Bowser Jr's clown body)