### PR TITLE
Fixed bug with OMO parsing

### DIFF
--- a/Smash Forge/Filetypes/Animation/OMO.cs
+++ b/Smash Forge/Filetypes/Animation/OMO.cs
@@ -193,7 +193,7 @@ namespace Smash_Forge
                         float y = baseNode[j].rv.Y;
                         float z = baseNode[j].rv.Z;
 
-                        float w = (float)Math.Sqrt(1 - (x * x + y * y + z * z));
+                        float w = (float)Math.Sqrt(Math.Abs(1 - (x * x + y * y + z * z)));
 
                         node.r = new Quaternion(baseNode[j].rv, w);
 


### PR DESCRIPTION
W value of some types of KeyNode was being calculated as NaN. This broke entire trees of models affected (the case that found this was ZSS' paralyser gun model/animation combo).