### PR TITLE
Fix hurtbox display

### DIFF
--- a/Smash Forge/GUI/Editors/RenderTools.cs
+++ b/Smash Forge/GUI/Editors/RenderTools.cs
@@ -190,6 +190,32 @@ namespace Smash_Forge
             }
         }
 
+        public static void drawSphereTransformedVisible(Vector3 center, float radius, uint precision, Matrix4 transform)
+        {
+            GL.Enable(EnableCap.StencilTest);
+
+            GL.StencilFunc(StencilFunction.Always, 1, 0xFF);
+            GL.StencilMask(0xFF);
+            GL.Disable(EnableCap.DepthTest);
+            GL.Clear(ClearBufferMask.StencilBufferBit);
+            GL.ColorMask(false, false, false, false);
+
+            drawSphereTransformed(center, radius, precision, transform);
+
+            GL.ColorMask(true, true, true, true);
+            GL.StencilFunc(StencilFunction.Equal, 1, 0xFF);
+            GL.StencilMask(0x00);
+            GL.Disable(EnableCap.CullFace);
+
+            drawSphere(Vector3.Zero, 100, 10);
+
+            GL.StencilMask(0xFF);
+            GL.Clear(ClearBufferMask.StencilBufferBit);
+            GL.Enable(EnableCap.StencilTest);
+            GL.Enable(EnableCap.DepthTest);
+            GL.Enable(EnableCap.CullFace);
+        }
+
         public static void drawSphereTransformed(Vector3 center, float radius, uint precision, Matrix4 transform)
         {
             if (radius < 0.0f)

--- a/Smash Forge/GUI/Editors/VBNViewport.Designer.cs
+++ b/Smash Forge/GUI/Editors/VBNViewport.Designer.cs
@@ -43,7 +43,7 @@
             this.btnLastFrame = new System.Windows.Forms.Button();
             this.btnPrevFrame = new System.Windows.Forms.Button();
             this.btnFirstFrame = new System.Windows.Forms.Button();
-            this.glControl1 = new OpenTK.GLControl(new OpenTK.Graphics.GraphicsMode(32, 24, 0, 16));
+            this.glControl1 = new OpenTK.GLControl(new OpenTK.Graphics.GraphicsMode(32, 24, 8, 16));
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nupdFrameRate)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nupdFrame)).BeginInit();

--- a/Smash Forge/GUI/Editors/VBNViewport.cs
+++ b/Smash Forge/GUI/Editors/VBNViewport.cs
@@ -1548,14 +1548,13 @@ namespace Smash_Forge
                         }
                     }
 
-                    GL.DepthMask(false);
                     var va2 = new Vector3(h.X2, h.Y2, h.Z2);
 
                     //if (h.Bone != -1)va2 = Vector3.Transform(va2, b.transform);
 
                     if (h.isSphere)
                     {
-                        RenderTools.drawSphereTransformed(va, h.Size, 30, b.transform);
+                        RenderTools.drawSphereTransformedVisible(va, h.Size, 30, b.transform);
                     }
                     else
                     {


### PR DESCRIPTION
Before this commit SmashForge shows a giant 100f unit radius sphere around the
model instead of showing the hurtbox cylinders.

Added 8 bits of stencil buffer to the GLControl. Note that this makes
hurtboxes and bones mutually exclusive right now since they don't play
nicely with depth/stencil.