### PR TITLE
Cleanup for LVD, add CLIFFs and improve data preservation; Add/modify param labels

### DIFF
--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -13,10 +13,75 @@ using System.Diagnostics;
 
 namespace Smash_Forge
 {
-    public class LVDEntry
+    public abstract class LVDEntry
     {
+        public abstract string magic { get; }
         public string name;
         public string subname;
+		public float[] startPos = new float[3];
+        public bool useStartPos = false;
+        public int unk1 = 0;
+        public float[] unk2 = new float[3];
+		public int unk3 = 0;
+        public char[] boneName = new char[0x40];
+		
+		public void read(FileData f)
+		{
+            f.skip(0xC);
+			
+			f.skip(1);
+            name = f.readString(f.pos(), 0x38);
+            f.skip(0x38);
+			
+            f.skip(1);
+            subname = f.readString(f.pos(), 0x40);
+            f.skip(0x40);
+			
+			f.skip(1);
+			for (int i = 0; i < 3; i++)
+				startPos[i] = f.readFloat();
+			useStartPos = Convert.ToBoolean(f.readByte());
+			
+			f.skip(1);
+			unk1 = f.readInt(); //Some kind of count? Only seen it as 0 so I don't know what it's for
+			
+			//Not sure what this is for, but it seems like an x,y,z followed by a hash
+			f.skip(1);
+			for (int i = 0; i < 3; i++)
+				unk2[i] = f.readFloat();
+			unk3 = f.readInt();
+			
+			f.skip(1);
+            boneName = new char[0x40];
+            for (int i = 0; i < 0x40; i++)
+                boneName[i] = (char)f.readByte();
+        }
+		public void save(FileOutput f)
+		{
+			f.writeHex(magic);
+			
+			f.writeByte(1);
+            f.writeString(name.PadRight(0x38, (char)0));
+			
+            f.writeByte(1);
+            f.writeString(subname.PadRight(0x40, (char)0));
+			
+            f.writeByte(1);
+            foreach (float i in startPos)
+                f.writeFloat(i);
+            f.writeFlag(useStartPos);
+			
+            f.writeByte(1);
+            f.writeInt(unk1);
+			
+			f.writeByte(1);
+			foreach (float i in unk2)
+                f.writeFloat(i);
+            f.writeInt(unk3);
+			
+			f.writeByte(1);
+            f.writeChars(boneName);
+		}
     }
 
     public class Vector2D
@@ -24,41 +89,14 @@ namespace Smash_Forge
         public float x;
         public float y;
     }
-
-    public class Sphere : LVDEntry
-    {
-        public float x;
-        public float y;
-        public float z;
-        public float radius;
-    }
-
-    public class Capsule : LVDEntry
-    {
-        public float x;
-        public float y;
-        public float z;
-        public float r;
-        public float dx;
-        public float dy;
-        public float dz;
-        public float unk;
-    }
-
+    
     public class Point : LVDEntry
     {
+        public override string magic { get { return ""; } }
         public float x;
         public float y;
     }
-
-    public class Bounds : LVDEntry //Either Camera bounds or Blast zones
-    {
-        public float top;
-        public float bottom;
-        public float left;
-        public float right;
-    }
-
+	
     public class CollisionMat
     {
         //public bool leftLedge;
@@ -95,117 +133,45 @@ namespace Smash_Forge
         }
     }
 
-    public class Section
+	public class CollisionCliff : LVDEntry
     {
-        public List<Vector2D> points = new List<Vector2D>();
+        public override string magic { get { return "030401017735BB7500000002"; } }
+		
+        public Vector2D pos;
+		public Vector2D angle; //Someone figure out what these angles are
+		
+		public void read(FileData f)
+		{
+			base.read(f);
+			
+			f.skip(1);
+			pos = new Vector2D();
+			pos.x = f.readFloat();
+            pos.y = f.readFloat();
+			angle = new Vector2D();
+			angle.x = f.readFloat();
+            angle.y = f.readFloat();
+        }
+		public void save(FileOutput f)
+		{
+			base.save(f);
+			
+			f.writeByte(1);
+			f.writeFloat(pos.x);
+			f.writeFloat(pos.y);
+			f.writeFloat(angle.x);
+			f.writeFloat(angle.y);
+		}
     }
-
-
-    public class ItemSpawner : LVDEntry
-    {
-        public List<Section> sections = new List<Section>();
-
-        public ItemSpawner()
-        {
-
-        }
-
-        public void read(FileData f)
-        {
-            f.skip(0xD);
-            name = f.readString(f.pos(), 0x38);
-            f.skip(0x38);
-            f.skip(1);//Seperation char
-            subname = f.readString(f.pos(), 0x40);
-            f.skip(0xAC);
-            int sectionCount = f.readInt();
-            for(int i = 0; i < sectionCount; i++)
-            {
-                f.skip(0x18);// unknown data
-                Section temp = new Section();
-                temp.points = new List<Vector2D>();
-                int vertCount = f.readInt();
-                for(int j = 0; j < vertCount; j++)
-                {
-                    f.skip(1);//Seperation char
-                    Vector2D point = new Vector2D();
-                    point.x = f.readFloat();
-                    point.y = f.readFloat();
-                    temp.points.Add(point);
-                }
-                sections.Add(temp);
-            }
-        }
-
-        public void save(FileOutput f)
-        {
-            f.writeHex("010401017735BB750000000201");
-            f.writeChars(name.PadRight(0x38,(char)0).ToCharArray());
-            f.writeByte(1);
-            f.writeChars(subname.PadRight(0x40, (char)0).ToCharArray());
-            f.writeHex("0100000000000000000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001098400010101");
-            f.writeInt(sections.Count);
-            foreach(Section s in sections)
-            {
-                f.writeHex("010300000004000000000000000000000000000000000101");
-                f.writeInt(s.points.Count);
-                foreach(Vector2D p in s.points)
-                {
-                    f.writeByte(1);
-                    f.writeFloat(p.x);
-                    f.writeFloat(p.y);
-                }
-            }
-        }
-    }
-
-    public class EnemyGenerator : LVDEntry
-    {
-        public List<Section> sections = new List<Section>();
-
-        public EnemyGenerator()
-        {
-
-        }
-
-        public void read(FileData f)
-        {
-            f.skip(0xD);
-            name = f.readString(f.pos(), 0x38);
-            f.skip(0x38);
-            f.skip(1);//Seperation char
-            subname = f.readString(f.pos(), 0x40);
-            f.skip(0xAC);
-            int sectionCount = f.readInt();
-            for (int i = 0; i < sectionCount; i++)
-            {
-                f.skip(0x18);// unknown data
-                Section temp = new Section();
-                temp.points = new List<Vector2D>();
-                int vertCount = f.readInt();
-                for (int j = 0; j < vertCount; j++)
-                {
-                    f.skip(1);//Seperation char
-                    Vector2D point = new Vector2D();
-                    point.x = f.readFloat();
-                    point.y = f.readFloat();
-                    temp.points.Add(point);
-                }
-                sections.Add(temp);
-            }
-        }
-    }
-
+	
     public class Collision : LVDEntry
     {
+        public override string magic { get { return "030401017735BB7500000002"; } }
+		
         public List<Vector2D> verts = new List<Vector2D>();
         public List<Vector2D> normals = new List<Vector2D>();
+        public List<CollisionCliff> cliffs = new List<CollisionCliff>();
         public List<CollisionMat> materials = new List<CollisionMat>();
-        public float[] startPos = new float[3];
-        public bool useStartPos = false;
-        public int unk2 = 0;
-        public byte[] unk3 = new byte[0xC];
-        public char[] unk4 = new char[0x40];
         public bool flag1 = false, flag2 = false, flag3 = false, flag4 = false;
 
         public Collision()
@@ -215,64 +181,49 @@ namespace Smash_Forge
 
         public void read(FileData f)
         {
-            f.skip(0xD);
-            name = f.readString(f.pos(), 0x38);
-            f.skip(0x38);
-            f.skip(1);//Seperation char
-            subname = f.readString(f.pos(), 0x40);
-            f.skip(0x40);
-            f.skip(1);//Seperation char
-            startPos[0] = f.readFloat();
-            startPos[1] = f.readFloat();
-            startPos[2] = f.readFloat();
-            useStartPos = (f.readByte() != 0);
-            f.skip(1);//Seperation char
-            unk2 = f.readInt();
-            f.skip(1);
-            unk3 = f.read(0xC);
-            f.skip(4);//FF FF FF FF
-            f.skip(1);//Seperation char
-            unk4 = new char[0x40];
-            for (int i = 0; i < 0x40; i++)
-                unk4[i] = (char)f.readByte();
+            base.read(f);
             
             flag1 = Convert.ToBoolean(f.readByte());
             flag2 = Convert.ToBoolean(f.readByte());
             flag3 = Convert.ToBoolean(f.readByte());
             flag4 = Convert.ToBoolean(f.readByte());
-            f.skip(1);//Seperation char
-            //f.skip(0xAA);
-            //Console.WriteLine(f.pos());
+			
+            f.skip(1);
             int vertCount = f.readInt();
             for(int i = 0; i < vertCount; i++)
             {
-                f.skip(1);//Seperation char
+                f.skip(1);
                 Vector2D temp = new Vector2D();
                 temp.x = f.readFloat();
                 temp.y = f.readFloat();
                 verts.Add(temp);
             }
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int normalCount = f.readInt();
             for(int i = 0; i < normalCount; i++)
             {
-                f.skip(1);//Seperation char
+                f.skip(1);
                 Vector2D temp = new Vector2D();
                 temp.x = f.readFloat();
                 temp.y = f.readFloat();
                 normals.Add(temp);
             }
-            f.skip(1);//Seperation char
-
-            int cliffCount = f.readInt();//CLIFFS tend to be useless
-            f.skip(0xFC * cliffCount);//Standard CLIFFS are 0xFC in length, just skip em all
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
+            int cliffCount = f.readInt();
+            for(int i = 0; i < cliffCount; i++)
+            {
+                CollisionCliff temp = new CollisionCliff();
+                temp.read(f);
+                cliffs.Add(temp);
+            }
+			
+            f.skip(1);
             int materialCount = f.readInt();
             for(int i = 0; i < materialCount; i++)
             {
-                f.skip(1);//Seperation char
+                f.skip(1);
                 CollisionMat temp = new CollisionMat();
                 temp.material = f.read(0xC);//Temporary, will work on fleshing out material more later
                 
@@ -280,27 +231,15 @@ namespace Smash_Forge
             }
 
         }
-
         public void save(FileOutput f)
         {
-            f.writeHex("030401017735BB750000000201");
-            f.writeString(name.PadRight(0x38, (char)0));
-            f.writeByte(1);
-            f.writeString(subname.PadRight(0x40, (char)0));
-            f.writeByte(1);
-            foreach (float i in startPos)
-                f.writeFloat(i);
-            f.writeFlag(useStartPos);
-            f.writeByte(1);
-            f.writeInt(unk2);
-            f.writeByte(1);
-            f.writeBytes(unk3);
-            f.writeHex("FFFFFFFF01");
-            f.writeChars(unk4);
+			base.save(f);
+
             f.writeFlag(flag1);
             f.writeFlag(flag2);
             f.writeFlag(flag3);
             f.writeFlag(flag4);
+			
             f.writeByte(1);
             f.writeInt(verts.Count);
             foreach(Vector2D v in verts)
@@ -309,6 +248,7 @@ namespace Smash_Forge
                 f.writeFloat(v.x);
                 f.writeFloat(v.y);
             }
+			
             f.writeByte(1);
             f.writeInt(normals.Count);
             foreach (Vector2D n in normals)
@@ -317,8 +257,14 @@ namespace Smash_Forge
                 f.writeFloat(n.x);
                 f.writeFloat(n.y);
             }
+			
             f.writeByte(1);
-            f.writeInt(0);
+            f.writeInt(cliffs.Count);
+			foreach (CollisionCliff c in cliffs)
+            {
+                c.save(f);
+            }
+			
             f.writeByte(1);
             f.writeInt(materials.Count);
             foreach (CollisionMat m in materials)
@@ -329,20 +275,181 @@ namespace Smash_Forge
         }
     }
 
-    public enum shape
+	public class Spawn : LVDEntry
+	{
+        public override string magic { get { return "020401017735BB7500000002"; } }
+		
+        public float x;
+        public float y;
+        
+		public void read(FileData f)
+		{
+			base.read(f);
+			
+			f.skip(1);
+			x = f.readFloat();
+			y = f.readFloat();
+        }
+		public void save(FileOutput f)
+		{
+			base.save(f);
+			
+			f.writeByte(1);
+			f.writeFloat(x);
+			f.writeFloat(y);
+		}
+	}
+	
+	public class Bounds : LVDEntry //For Camera Bounds and Blast Zones
+    {
+		public override string magic { get { return "020401017735BB7500000002"; } }
+		
+        public float top;
+        public float bottom;
+        public float left;
+        public float right;
+		
+		public void read(FileData f)
+		{
+			base.read(f);
+			
+			f.skip(1);
+			left = f.readFloat();
+			right = f.readFloat();
+			top = f.readFloat();
+			bottom = f.readFloat();
+        }
+		public void save(FileOutput f)
+		{
+			base.save(f);
+			
+			f.writeByte(1);
+			f.writeFloat(left);
+			f.writeFloat(right);
+			f.writeFloat(top);
+			f.writeFloat(bottom);
+		}
+    }
+
+    public class Section
+    {
+        public List<Vector2D> points = new List<Vector2D>();
+		
+        public void read(FileData f)
+        {
+			f.skip(1);
+			f.skip(0x16);// unknown data
+			
+			f.skip(1);
+			points = new List<Vector2D>();
+			int vertCount = f.readInt();
+			for(int j = 0; j < vertCount; j++)
+			{
+				f.skip(1);
+				Vector2D point = new Vector2D();
+				point.x = f.readFloat();
+				point.y = f.readFloat();
+				points.Add(point);
+			}
+        }
+        public void save(FileOutput f)
+        {
+			f.writeByte(1);
+			f.writeHex("03000000040000000000000000000000000000000001");
+			
+            f.writeByte(1);
+            f.writeInt(points.Count);
+            foreach(Vector2D v in points)
+            {
+                f.writeByte(1);
+                f.writeFloat(v.x);
+                f.writeFloat(v.y);
+            }
+		}
+    }
+
+
+    public class ItemSpawner : LVDEntry
+    {
+		public override string magic { get { return "010401017735BB7500000002"; } }
+		
+        public List<Section> sections = new List<Section>();
+
+        public ItemSpawner()
+        {
+
+        }
+
+        public void read(FileData f)
+        {
+            base.read(f);
+			
+			f.skip(1);
+			f.skip(0x5);// unknown
+			
+            f.skip(1);
+            int sectionCount = f.readInt();
+            for(int i = 0; i < sectionCount; i++)
+            {
+				Section temp = new Section();
+				temp.read(f);
+                sections.Add(temp);
+            }
+        }
+        public void save(FileOutput f)
+        {
+            base.save(f);
+			
+			f.writeByte(1);
+			f.writeHex("0984000101");
+			
+			f.writeByte(1);
+			f.writeInt(sections.Count);
+            foreach(Section s in sections)
+            {
+				s.save(f);
+            }
+        }
+    }
+
+    public class EnemyGenerator : ItemSpawner
+    {
+        
+    }
+
+    public enum shape //I don't think these are accurate
     {
         point = 1,
         rectangle = 3,
         path = 4
     }
 
-    public abstract class LVDGeneralShape : LVDEntry
+    public class LVDGeneralShape : LVDEntry
     {
+		public override string magic { get { return "010401017735BB7500000002"; } }
+		
         public int type;
 
-        public abstract void Read(FileData f);
-
-        public abstract void save(FileOutput f);
+        public void read(FileData f)
+		{
+			base.read(f);
+			
+			f.skip(1);
+			f.readInt(); //unknown
+			
+			f.skip(1);
+			type = f.readInt();
+		}
+        public void save(FileOutput f)
+		{
+			base.save(f);
+			
+			f.writeByte(1);
+			f.writeInt(0);
+			
+			f.writeByte(1);
+			f.writeInt(type);
+		}
     }
 
     public class GeneralPoint : LVDGeneralShape
@@ -354,24 +461,21 @@ namespace Smash_Forge
             type = 1;
         }
 
-        public override void Read(FileData f)
+        public void read(FileData f)
         {
+			base.read(f);
+			
             x = f.readFloat();
             y = f.readFloat();
-            f.skip(0xE);
+            f.skip(0x14);
         }
-
-        public override void save(FileOutput f)
+        public void save(FileOutput f)
         {
-            f.writeHex("010401017735BB750000000201");
-            f.writeChars(name.PadRight(0x38).ToCharArray());
-            f.writeByte(1);
-            f.writeChars(subname.PadRight(0x40).ToCharArray());
-            f.writeHex("0100000000000000000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001014C800203");
-            f.writeInt(type);
+            base.save(f);
+			
             f.writeFloat(x);
             f.writeFloat(y);
-            f.writeHex("0000000000000000010100000000");
+            f.writeHex("0000000000000000000000000000000000000000");
         }
     }
 
@@ -384,8 +488,10 @@ namespace Smash_Forge
             type = 3;
         }
 
-        public override void Read(FileData f)
+        public void read(FileData f)
         {
+			base.read(f);
+		
             x1 = f.readFloat();
             y1 = f.readFloat();
             x2 = f.readFloat();
@@ -393,14 +499,10 @@ namespace Smash_Forge
             f.skip(0x6);
         }
 
-        public override void save(FileOutput f)
+        public void save(FileOutput f)
         {
-            f.writeHex("010401017735BB750000000201");
-            f.writeChars(name.PadRight(0x38).ToCharArray());
-            f.writeByte(1);
-            f.writeChars(subname.PadRight(0x40).ToCharArray());
-            f.writeHex("0100000000000000000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001014C800203");
-            f.writeInt(type);
+            base.save(f);
+			
             f.writeFloat(x1);
             f.writeFloat(y1);
             f.writeFloat(x2);
@@ -418,25 +520,23 @@ namespace Smash_Forge
             type = 4;
         }
 
-        public override void Read(FileData f)
+        public void read(FileData f)
         {
+			base.read(f);
+			
             f.skip(0x12);
             int pointCount = f.readInt();
             for(int i = 0; i < pointCount; i++)
             {
-                f.skip(1);//seperator char
+                f.skip(1);
                 points.Add(new Vector2D() { x = f.readFloat(), y = f.readFloat() });
             }
         }
 
-        public override void save(FileOutput f)
+        public void save(FileOutput f)
         {
-            f.writeHex("010401017735BB750000000201");
-            f.writeChars(name.PadRight(0x38).ToCharArray());
-            f.writeByte(1);
-            f.writeChars(subname.PadRight(0x40).ToCharArray());
-            f.writeHex("0100000000000000000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001014C800203");
-            f.writeInt(type);
+            base.save(f);
+			
             f.writeHex("000000000000000000000000000000000101");
             f.writeInt(points.Count);
             foreach (Vector2D point in points)
@@ -447,34 +547,56 @@ namespace Smash_Forge
             }
         }
     }
+	
+    public class Sphere : LVDEntry
+    {
+		public override string magic { get { return "030401017735BB7500000002"; } }
+        public float x;
+        public float y;
+        public float z;
+        public float radius;
+    }
+
+    public class Capsule : LVDEntry
+    {
+        public override string magic { get { return "030401017735BB7500000002"; } }
+        public float x;
+        public float y;
+        public float z;
+        public float r;
+        public float dx;
+        public float dy;
+        public float dz;
+        public float unk;
+    }
 
     public class LVD : FileBase
     { 
         public LVD()
         {
             collisions = new List<Collision>();
-            spawns = new List<Point>();
-            respawns = new List<Point>();
+            spawns = new List<Spawn>();
+            respawns = new List<Spawn>();
             cameraBounds = new List<Bounds>();
             blastzones = new List<Bounds>();
-            generalPoints = new List<Point>();
+            generalShapes = new List<LVDGeneralShape>();
+            generalPoints = new List<GeneralPoint>();
             damageSpheres = new List<Sphere>();
             items = new List<ItemSpawner>();
             damageCapsules = new List<Capsule>();
             enemySpawns = new List<EnemyGenerator>();
-            generalShapes = new List<LVDGeneralShape>();
         }
         public LVD(string filename) : this()
         {
             Read(filename);
         }
         public List<Collision> collisions { get; set; }
-        public List<Point> spawns { get; set; }
-        public List<Point> respawns { get; set; }
+        public List<Spawn> spawns { get; set; }
+        public List<Spawn> respawns { get; set; }
         public List<Bounds> cameraBounds { get; set; }
         public List<Bounds> blastzones { get; set; }
         public List<LVDGeneralShape> generalShapes { get; set; }
-        public List<Point> generalPoints { get; set; }
+        public List<GeneralPoint> generalPoints { get; set; }
         public List<Sphere> damageSpheres { get; set; }
         public List<ItemSpawner> items { get; set; }
         public List<Capsule> damageCapsules { get; set; }
@@ -505,7 +627,9 @@ namespace Smash_Forge
         public override void Read(string filename)
         {
             FileData f = new FileData(filename);
-            f.seek(0xB);//It's magic
+            f.skip(0xA);//It's magic
+			
+			f.skip(1);
             int collisionCount = f.readInt();
             for (int i = 0; i < collisionCount; i++)
             {
@@ -513,103 +637,71 @@ namespace Smash_Forge
                 temp.read(f);
                 collisions.Add(temp);
             }
-            f.skip(1); //Seperation char
-
+			
+            f.skip(1);
             int spawnCount = f.readInt();
             for (int i = 0; i < spawnCount; i++)
             {
-                Point temp = new Point();
-                f.skip(0xD);
-                temp.name = f.readString(f.pos(), 0x38);
-                f.skip(0x38);
-                f.skip(1);//Seperation char
-                temp.subname = f.readString(f.pos(), 0x40);
-                f.skip(0xA6);
-                temp.x = f.readFloat();
-                temp.y = f.readFloat();
+                Spawn temp = new Spawn();
+                temp.read(f);
                 spawns.Add(temp);
             }
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int respawnCount = f.readInt();
             for (int i = 0; i < respawnCount; i++)
             {
-                Point temp = new Point();
-                f.skip(0xD);
-                temp.name = f.readString(f.pos(), 0x38);
-                f.skip(0x38);
-                f.skip(1);//Seperation char
-                temp.subname = f.readString(f.pos(), 0x40);
-                f.skip(0xA6);
-                temp.x = f.readFloat();
-                temp.y = f.readFloat();
+                Spawn temp = new Spawn();
+                temp.read(f);
                 respawns.Add(temp);
             }
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int cameraCount = f.readInt();
             for (int i = 0; i < cameraCount; i++)
             {
                 Bounds temp = new Bounds();
-                f.skip(0xD);
-                temp.name = f.readString(f.pos(), 0x38);
-                f.skip(0x38);
-                f.skip(1);//Seperation char
-                temp.subname = f.readString(f.pos(), 0x40);
-                f.skip(0xA6);
-                temp.left = f.readFloat();
-                temp.right = f.readFloat();
-                temp.top = f.readFloat();
-                temp.bottom = f.readFloat();
+                temp.read(f);
                 cameraBounds.Add(temp);
             }
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int blastzoneCount = f.readInt();
             for (int i = 0; i < blastzoneCount; i++)
             {
                 Bounds temp = new Bounds();
-                f.skip(0xD);
-                temp.name = f.readString(f.pos(), 0x38);
-                f.skip(0x38);
-                f.skip(1);//Seperation char
-                temp.subname = f.readString(f.pos(), 0x40);
-                f.skip(0xA6);
-                temp.left = f.readFloat();
-                temp.right = f.readFloat();
-                temp.top = f.readFloat();
-                temp.bottom = f.readFloat();
+                temp.read(f);
                 blastzones.Add(temp);
             }
-            f.skip(1);//Seperation char
-
-            if (f.readInt() != 0) //1
+			
+            f.skip(1);
+            if (f.readInt() != 0) //6
                 return;
-            f.skip(1);//Seperation char
-
-            if (f.readInt() != 0)//2
+				
+            f.skip(1);
+            if (f.readInt() != 0) //7
                 return;
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int enemyGeneratorCount = f.readInt();
-            if (enemyGeneratorCount != 0)
+            if (enemyGeneratorCount != 0) //Are these just item spawners?
                 return;
-            f.skip(1);//Seperation char
-
-            if (f.readInt() != 0)//4
+			
+            f.skip(1);
+            if (f.readInt() != 0) //9
                 return;
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int fsAreaCamCount = f.readInt();
             if (fsAreaCamCount != 0)
                 return;
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int fsCamLimitCount = f.readInt();
             if (fsCamLimitCount != 0)
                 return;
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int damageShapeCount = f.readInt();
             for(int i=0; i < damageShapeCount; i++)
             {
@@ -617,7 +709,7 @@ namespace Smash_Forge
 
                 string tempName = f.readString(f.pos(), 0x38);
                 f.skip(0x38);
-                f.skip(1);//Seperation char
+                f.skip(1);
                 string tempSubname = f.readString(f.pos(), 0x40);
                 f.skip(0xA6);
                 int shapeType = f.readInt();
@@ -653,8 +745,8 @@ namespace Smash_Forge
                     throw new NotImplementedException();
                 }
             }
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int itemCount = f.readInt();
             for(int i = 0; i < itemCount; i++)
             {
@@ -662,74 +754,50 @@ namespace Smash_Forge
                 temp.read(f);
                 items.Add(temp);
             }
-            f.skip(1);//Seperation char
-
+			
+            f.skip(1);
             int generalShapeCount = f.readInt();
             for (int i = 0; i < generalShapeCount; i++)
             {
-                f.skip(0xD);
-
-                string tempName = f.readString(f.pos(), 0x38);
-                f.skip(0x38);
-                f.skip(1);//Seperation char
-                string tempSubname = f.readString(f.pos(), 0x40);
-                f.skip(0xAB);
-                int shapeType = f.readInt();
-                LVDGeneralShape p;
-                if (shapeType == 1)
+                int tempOff = f.pos();
+                LVDGeneralShape p = new LVDGeneralShape();
+				f.seek(tempOff);
+                if (p.type == 1)
                     p = new GeneralPoint();
-                else if (shapeType == 3)
+                else if (p.type == 3)
                     p = new GeneralRect();
-                else if (shapeType == 4)
+                else if (p.type == 4)
                     p = new GeneralPath();
                 else
-                    throw new Exception($"Unknown shape type {shapeType} at offset {f.pos() - 4}");
-                p.name = tempName;
-                p.subname = tempSubname;
-                p.Read(f);
+                    throw new Exception($"Unknown shape type {p.type} at offset {tempOff}");
+                p.read(f);
                 generalShapes.Add(p);
             }
+			
             f.skip(1);
-
             int generalPointCount = f.readInt();
             for(int i = 0; i < generalPointCount; i++)
             {
-                Point temp = new Point();
-                f.skip(0xD);
-                temp.name = f.readString(f.pos(), 0x38);
-                f.skip(0x38);
-                f.skip(1);//Seperation char
-                temp.subname = f.readString(f.pos(), 0x40);
-                f.skip(0xAF);
-                temp.x = f.readFloat();
-                temp.y = f.readFloat();
-                f.skip(0x14);
+                GeneralPoint temp = new GeneralPoint();
+                temp.read(f);
                 generalPoints.Add(temp);
             }
 
-            if (f.readInt() != 0)//8
+			f.skip(1);
+            if (f.readInt() != 0) //16
                 return; //no clue how to be consistent in reading these so...
+				
             f.skip(1);
-
-            if (f.readInt() != 0)//8
+            if (f.readInt() != 0) //17
                 return; //no clue how to be consistent in reading these so...
+				
             f.skip(1);
-
-            if (f.readInt() != 0)//8
+            if (f.readInt() != 0) //18
                 return; //no clue how to be consistent in reading these so...
+			
             f.skip(1);
-
-            if (f.readInt() != 0)//8
+            if (f.readInt() != 0) //19
                 return; //no clue how to be consistent in reading these so...
-            f.skip(1);
-
-            if (f.readInt() != 0)//8
-                return; //no clue how to be consistent in reading these so...
-            f.skip(1);
-
-            if (f.readInt() != 0)//8
-                return; //no clue how to be consistent in reading these so...
-            f.skip(1);
 
             //LVD doesn't end here and neither does my confusion, will update this part later
         }
@@ -739,68 +807,32 @@ namespace Smash_Forge
             FileOutput f = new FileOutput();
             f.Endian = Endianness.Big;
 
-            f.writeHex("000000010A014C56443101");
+            f.writeHex("000000010A014C564431");
+			
+			f.writeByte(1);
             f.writeInt(collisions.Count);
             foreach (Collision c in collisions)
-            {
                 c.save(f);
-            }
+			
             f.writeByte(1);
             f.writeInt(spawns.Count);
-            foreach (Point p in spawns)
-            {
-                f.writeHex("020401017735BB750000000201");
-                f.writeString(p.name.PadRight(0x38, (char)0));
-                f.writeByte(1);
-                f.writeString(p.subname.PadRight(0x40, (char)0));
-                f.writeByte(1);
-                f.writeHex("00000000000000000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001");
-                f.writeFloat(p.x);
-                f.writeFloat(p.y);
-            }
+            foreach (Spawn s in spawns)
+                s.save(f);
+			
             f.writeByte(1);
-            f.writeInt(respawns.Count);
-            foreach (Point p in respawns)
-            {
-                f.writeHex("020401017735BB750000000201");
-                f.writeString(p.name.PadRight(0x38, (char)0));
-                f.writeByte(1);
-                f.writeString(p.subname.PadRight(0x40, (char)0));
-                f.writeByte(1);
-                f.writeHex("00000000000000000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001");
-                f.writeFloat(p.x);
-                f.writeFloat(p.y);
-            }
+            f.writeInt(spawns.Count);
+            foreach (Spawn s in respawns)
+                s.save(f);
+			
             f.writeByte(1);
             f.writeInt(cameraBounds.Count);
             foreach (Bounds b in cameraBounds)
-            {
-                f.writeHex("020401017735BB750000000201");
-                f.writeString(b.name.PadRight(0x38, (char)0));
-                f.writeByte(1);
-                f.writeString(b.subname.PadRight(0x40, (char)0));
-                f.writeByte(1);
-                f.writeHex("00000000000000000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001");
-                f.writeFloat(b.left);
-                f.writeFloat(b.right);
-                f.writeFloat(b.top);
-                f.writeFloat(b.bottom);
-            }
+                b.save(f);
+			
             f.writeByte(1);
             f.writeInt(blastzones.Count);
             foreach (Bounds b in blastzones)
-            {
-                f.writeHex("020401017735BB750000000201");
-                f.writeString(b.name.PadRight(0x38, (char)0));
-                f.writeByte(1);
-                f.writeString(b.subname.PadRight(0x40, (char)0));
-                f.writeByte(1);
-                f.writeHex("00000000000000000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001");
-                f.writeFloat(b.left);
-                f.writeFloat(b.right);
-                f.writeFloat(b.top);
-                f.writeFloat(b.bottom);
-            }
+				b.save(f);
 
             for (int i = 0; i < 7; i++)
             {
@@ -821,18 +853,8 @@ namespace Smash_Forge
 
             f.writeByte(1);
             f.writeInt(generalPoints.Count);
-            foreach (Point p in generalPoints)
-            {
-                f.writeHex("010401017735BB750000000201");
-                f.writeChars(p.name.PadRight(0x38,(char)0).ToCharArray());
-                f.writeByte(1);
-                f.writeChars(p.subname.PadRight(0x40, (char)0).ToCharArray());
-                f.writeByte(1);
-                f.writeHex("00000000432100000000000000010000000001000000000000000000000000FFFFFFFF010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000100000004");
-                f.writeFloat(p.x);
-                f.writeFloat(p.y);
-                f.writeBytes(new byte[0x14]);
-            }
+            foreach (GeneralPoint p in generalPoints)
+                p.save(f);
 
             for (int i = 0; i < 4; i++)
             {
@@ -845,7 +867,7 @@ namespace Smash_Forge
 
         #region rendering
 
-        public static void DrawSpawn(Point s, bool isRespawn)
+        public static void DrawSpawn(Spawn s, bool isRespawn)
         {
             DrawRespawnQuad(s, Color.Blue);
 
@@ -857,7 +879,7 @@ namespace Smash_Forge
 
         }
 
-        private static void DrawRespawnQuad(Point s, Color color)
+        private static void DrawRespawnQuad(Spawn s, Color color)
         {
             float width = 3.0f;
             float height = 10.0f;
@@ -870,7 +892,7 @@ namespace Smash_Forge
             GL.End();
         }
 
-        private static void DrawRespawnArrow(Point s, Color arrowColor, Color wireframeColor)
+        private static void DrawRespawnArrow(Spawn s, Color arrowColor, Color wireframeColor)
         {
             float scale = 5.0f;
             GL.Color4(Color.FromArgb(200, arrowColor));
@@ -1004,7 +1026,7 @@ namespace Smash_Forge
                             {
                                 foreach (Bone b in m.vbn.bones)
                                 {
-                                    if (b.Text.Equals(new string(c.unk4)))
+                                    if (b.Equals(c.boneName))
                                     {
                                         riggedBone = b;
                                     }

--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -18,70 +18,70 @@ namespace Smash_Forge
         public abstract string magic { get; }
         public string name;
         public string subname;
-		public float[] startPos = new float[3];
+        public float[] startPos = new float[3];
         public bool useStartPos = false;
         public int unk1 = 0;
         public float[] unk2 = new float[3];
-		public int unk3 = 0;
+        public int unk3 = 0;
         public char[] boneName = new char[0x40];
-		
-		public void read(FileData f)
-		{
+        
+        public void read(FileData f)
+        {
             f.skip(0xC);
-			
-			f.skip(1);
+            
+            f.skip(1);
             name = f.readString(f.pos(), 0x38);
             f.skip(0x38);
-			
+            
             f.skip(1);
             subname = f.readString(f.pos(), 0x40);
             f.skip(0x40);
-			
-			f.skip(1);
-			for (int i = 0; i < 3; i++)
-				startPos[i] = f.readFloat();
-			useStartPos = Convert.ToBoolean(f.readByte());
-			
-			f.skip(1);
-			unk1 = f.readInt(); //Some kind of count? Only seen it as 0 so I don't know what it's for
-			
-			//Not sure what this is for, but it seems like an x,y,z followed by a hash
-			f.skip(1);
-			for (int i = 0; i < 3; i++)
-				unk2[i] = f.readFloat();
-			unk3 = f.readInt();
-			
-			f.skip(1);
+            
+            f.skip(1);
+            for (int i = 0; i < 3; i++)
+                startPos[i] = f.readFloat();
+            useStartPos = Convert.ToBoolean(f.readByte());
+            
+            f.skip(1);
+            unk1 = f.readInt(); //Some kind of count? Only seen it as 0 so I don't know what it's for
+            
+            //Not sure what this is for, but it seems like an x,y,z followed by a hash
+            f.skip(1);
+            for (int i = 0; i < 3; i++)
+                unk2[i] = f.readFloat();
+            unk3 = f.readInt();
+            
+            f.skip(1);
             boneName = new char[0x40];
             for (int i = 0; i < 0x40; i++)
                 boneName[i] = (char)f.readByte();
         }
-		public void save(FileOutput f)
-		{
-			f.writeHex(magic);
-			
-			f.writeByte(1);
+        public void save(FileOutput f)
+        {
+            f.writeHex(magic);
+            
+            f.writeByte(1);
             f.writeString(name.PadRight(0x38, (char)0));
-			
+            
             f.writeByte(1);
             f.writeString(subname.PadRight(0x40, (char)0));
-			
+            
             f.writeByte(1);
             foreach (float i in startPos)
                 f.writeFloat(i);
             f.writeFlag(useStartPos);
-			
+            
             f.writeByte(1);
             f.writeInt(unk1);
-			
-			f.writeByte(1);
-			foreach (float i in unk2)
+            
+            f.writeByte(1);
+            foreach (float i in unk2)
                 f.writeFloat(i);
             f.writeInt(unk3);
-			
-			f.writeByte(1);
+            
+            f.writeByte(1);
             f.writeChars(boneName);
-		}
+        }
     }
 
     public class Vector2D
@@ -96,7 +96,7 @@ namespace Smash_Forge
         public float x;
         public float y;
     }
-	
+    
     public class CollisionMat
     {
         //public bool leftLedge;
@@ -133,41 +133,41 @@ namespace Smash_Forge
         }
     }
 
-	public class CollisionCliff : LVDEntry
+    public class CollisionCliff : LVDEntry
     {
         public override string magic { get { return "030401017735BB7500000002"; } }
-		
+        
         public Vector2D pos;
-		public Vector2D angle; //Someone figure out what these angles are
-		
-		public void read(FileData f)
-		{
-			base.read(f);
-			
-			f.skip(1);
-			pos = new Vector2D();
-			pos.x = f.readFloat();
+        public Vector2D angle; //Someone figure out what these angles are
+        
+        public void read(FileData f)
+        {
+            base.read(f);
+            
+            f.skip(1);
+            pos = new Vector2D();
+            pos.x = f.readFloat();
             pos.y = f.readFloat();
-			angle = new Vector2D();
-			angle.x = f.readFloat();
+            angle = new Vector2D();
+            angle.x = f.readFloat();
             angle.y = f.readFloat();
         }
-		public void save(FileOutput f)
-		{
-			base.save(f);
-			
-			f.writeByte(1);
-			f.writeFloat(pos.x);
-			f.writeFloat(pos.y);
-			f.writeFloat(angle.x);
-			f.writeFloat(angle.y);
-		}
+        public void save(FileOutput f)
+        {
+            base.save(f);
+            
+            f.writeByte(1);
+            f.writeFloat(pos.x);
+            f.writeFloat(pos.y);
+            f.writeFloat(angle.x);
+            f.writeFloat(angle.y);
+        }
     }
-	
+    
     public class Collision : LVDEntry
     {
         public override string magic { get { return "030401017735BB7500000002"; } }
-		
+        
         public List<Vector2D> verts = new List<Vector2D>();
         public List<Vector2D> normals = new List<Vector2D>();
         public List<CollisionCliff> cliffs = new List<CollisionCliff>();
@@ -187,7 +187,7 @@ namespace Smash_Forge
             flag2 = Convert.ToBoolean(f.readByte());
             flag3 = Convert.ToBoolean(f.readByte());
             flag4 = Convert.ToBoolean(f.readByte());
-			
+            
             f.skip(1);
             int vertCount = f.readInt();
             for(int i = 0; i < vertCount; i++)
@@ -198,7 +198,7 @@ namespace Smash_Forge
                 temp.y = f.readFloat();
                 verts.Add(temp);
             }
-			
+            
             f.skip(1);
             int normalCount = f.readInt();
             for(int i = 0; i < normalCount; i++)
@@ -209,7 +209,7 @@ namespace Smash_Forge
                 temp.y = f.readFloat();
                 normals.Add(temp);
             }
-			
+            
             f.skip(1);
             int cliffCount = f.readInt();
             for(int i = 0; i < cliffCount; i++)
@@ -218,7 +218,7 @@ namespace Smash_Forge
                 temp.read(f);
                 cliffs.Add(temp);
             }
-			
+            
             f.skip(1);
             int materialCount = f.readInt();
             for(int i = 0; i < materialCount; i++)
@@ -233,13 +233,13 @@ namespace Smash_Forge
         }
         public void save(FileOutput f)
         {
-			base.save(f);
+            base.save(f);
 
             f.writeFlag(flag1);
             f.writeFlag(flag2);
             f.writeFlag(flag3);
             f.writeFlag(flag4);
-			
+            
             f.writeByte(1);
             f.writeInt(verts.Count);
             foreach(Vector2D v in verts)
@@ -248,7 +248,7 @@ namespace Smash_Forge
                 f.writeFloat(v.x);
                 f.writeFloat(v.y);
             }
-			
+            
             f.writeByte(1);
             f.writeInt(normals.Count);
             foreach (Vector2D n in normals)
@@ -257,14 +257,14 @@ namespace Smash_Forge
                 f.writeFloat(n.x);
                 f.writeFloat(n.y);
             }
-			
+            
             f.writeByte(1);
             f.writeInt(cliffs.Count);
-			foreach (CollisionCliff c in cliffs)
+            foreach (CollisionCliff c in cliffs)
             {
                 c.save(f);
             }
-			
+            
             f.writeByte(1);
             f.writeInt(materials.Count);
             foreach (CollisionMat m in materials)
@@ -275,88 +275,88 @@ namespace Smash_Forge
         }
     }
 
-	public class Spawn : LVDEntry
-	{
+    public class Spawn : LVDEntry
+    {
         public override string magic { get { return "020401017735BB7500000002"; } }
-		
+        
         public float x;
         public float y;
         
-		public void read(FileData f)
-		{
-			base.read(f);
-			
-			f.skip(1);
-			x = f.readFloat();
-			y = f.readFloat();
+        public void read(FileData f)
+        {
+            base.read(f);
+            
+            f.skip(1);
+            x = f.readFloat();
+            y = f.readFloat();
         }
-		public void save(FileOutput f)
-		{
-			base.save(f);
-			
-			f.writeByte(1);
-			f.writeFloat(x);
-			f.writeFloat(y);
-		}
-	}
-	
-	public class Bounds : LVDEntry //For Camera Bounds and Blast Zones
+        public void save(FileOutput f)
+        {
+            base.save(f);
+            
+            f.writeByte(1);
+            f.writeFloat(x);
+            f.writeFloat(y);
+        }
+    }
+    
+    public class Bounds : LVDEntry //For Camera Bounds and Blast Zones
     {
-		public override string magic { get { return "020401017735BB7500000002"; } }
-		
+        public override string magic { get { return "020401017735BB7500000002"; } }
+        
         public float top;
         public float bottom;
         public float left;
         public float right;
-		
-		public void read(FileData f)
-		{
-			base.read(f);
-			
-			f.skip(1);
-			left = f.readFloat();
-			right = f.readFloat();
-			top = f.readFloat();
-			bottom = f.readFloat();
+        
+        public void read(FileData f)
+        {
+            base.read(f);
+            
+            f.skip(1);
+            left = f.readFloat();
+            right = f.readFloat();
+            top = f.readFloat();
+            bottom = f.readFloat();
         }
-		public void save(FileOutput f)
-		{
-			base.save(f);
-			
-			f.writeByte(1);
-			f.writeFloat(left);
-			f.writeFloat(right);
-			f.writeFloat(top);
-			f.writeFloat(bottom);
-		}
+        public void save(FileOutput f)
+        {
+            base.save(f);
+            
+            f.writeByte(1);
+            f.writeFloat(left);
+            f.writeFloat(right);
+            f.writeFloat(top);
+            f.writeFloat(bottom);
+        }
     }
 
     public class Section
     {
         public List<Vector2D> points = new List<Vector2D>();
-		
+        
         public void read(FileData f)
         {
-			f.skip(1);
-			f.skip(0x16);// unknown data
-			
-			f.skip(1);
-			points = new List<Vector2D>();
-			int vertCount = f.readInt();
-			for(int j = 0; j < vertCount; j++)
-			{
-				f.skip(1);
-				Vector2D point = new Vector2D();
-				point.x = f.readFloat();
-				point.y = f.readFloat();
-				points.Add(point);
-			}
+            f.skip(1);
+            f.skip(0x16);// unknown data
+            
+            f.skip(1);
+            points = new List<Vector2D>();
+            int vertCount = f.readInt();
+            for(int j = 0; j < vertCount; j++)
+            {
+                f.skip(1);
+                Vector2D point = new Vector2D();
+                point.x = f.readFloat();
+                point.y = f.readFloat();
+                points.Add(point);
+            }
         }
         public void save(FileOutput f)
         {
-			f.writeByte(1);
-			f.writeHex("03000000040000000000000000000000000000000001");
-			
+            f.writeByte(1);
+            f.writeHex("03000000040000000000000000000000000000000001");
+            
             f.writeByte(1);
             f.writeInt(points.Count);
             foreach(Vector2D v in points)
@@ -365,14 +365,14 @@ namespace Smash_Forge
                 f.writeFloat(v.x);
                 f.writeFloat(v.y);
             }
-		}
+        }
     }
 
 
     public class ItemSpawner : LVDEntry
     {
-		public override string magic { get { return "010401017735BB7500000002"; } }
-		
+        public override string magic { get { return "010401017735BB7500000002"; } }
+        
         public List<Section> sections = new List<Section>();
 
         public ItemSpawner()
@@ -383,31 +383,31 @@ namespace Smash_Forge
         public void read(FileData f)
         {
             base.read(f);
-			
-			f.skip(1);
-			f.skip(0x5);// unknown
-			
+            
+            f.skip(1);
+            f.skip(0x5);// unknown
+            
             f.skip(1);
             int sectionCount = f.readInt();
             for(int i = 0; i < sectionCount; i++)
             {
-				Section temp = new Section();
-				temp.read(f);
+                Section temp = new Section();
+                temp.read(f);
                 sections.Add(temp);
             }
         }
         public void save(FileOutput f)
         {
             base.save(f);
-			
-			f.writeByte(1);
-			f.writeHex("0984000101");
-			
-			f.writeByte(1);
-			f.writeInt(sections.Count);
+            
+            f.writeByte(1);
+            f.writeHex("0984000101");
+            
+            f.writeByte(1);
+            f.writeInt(sections.Count);
             foreach(Section s in sections)
             {
-				s.save(f);
+                s.save(f);
             }
         }
     }
@@ -426,30 +426,30 @@ namespace Smash_Forge
 
     public class LVDGeneralShape : LVDEntry
     {
-		public override string magic { get { return "010401017735BB7500000002"; } }
-		
+        public override string magic { get { return "010401017735BB7500000002"; } }
+        
         public int type;
 
         public void read(FileData f)
-		{
-			base.read(f);
-			
-			f.skip(1);
-			f.readInt(); //unknown
-			
-			f.skip(1);
-			type = f.readInt();
-		}
+        {
+            base.read(f);
+            
+            f.skip(1);
+            f.readInt(); //unknown
+            
+            f.skip(1);
+            type = f.readInt();
+        }
         public void save(FileOutput f)
-		{
-			base.save(f);
-			
-			f.writeByte(1);
-			f.writeInt(0);
-			
-			f.writeByte(1);
-			f.writeInt(type);
-		}
+        {
+            base.save(f);
+            
+            f.writeByte(1);
+            f.writeInt(0);
+            
+            f.writeByte(1);
+            f.writeInt(type);
+        }
     }
 
     public class GeneralPoint : LVDGeneralShape
@@ -463,8 +463,8 @@ namespace Smash_Forge
 
         public void read(FileData f)
         {
-			base.read(f);
-			
+            base.read(f);
+            
             x = f.readFloat();
             y = f.readFloat();
             f.skip(0x14);
@@ -472,7 +472,7 @@ namespace Smash_Forge
         public void save(FileOutput f)
         {
             base.save(f);
-			
+            
             f.writeFloat(x);
             f.writeFloat(y);
             f.writeHex("0000000000000000000000000000000000000000");
@@ -490,8 +490,8 @@ namespace Smash_Forge
 
         public void read(FileData f)
         {
-			base.read(f);
-		
+            base.read(f);
+        
             x1 = f.readFloat();
             y1 = f.readFloat();
             x2 = f.readFloat();
@@ -502,7 +502,7 @@ namespace Smash_Forge
         public void save(FileOutput f)
         {
             base.save(f);
-			
+            
             f.writeFloat(x1);
             f.writeFloat(y1);
             f.writeFloat(x2);
@@ -522,8 +522,8 @@ namespace Smash_Forge
 
         public void read(FileData f)
         {
-			base.read(f);
-			
+            base.read(f);
+            
             f.skip(0x12);
             int pointCount = f.readInt();
             for(int i = 0; i < pointCount; i++)
@@ -536,7 +536,7 @@ namespace Smash_Forge
         public void save(FileOutput f)
         {
             base.save(f);
-			
+            
             f.writeHex("000000000000000000000000000000000101");
             f.writeInt(points.Count);
             foreach (Vector2D point in points)
@@ -547,10 +547,10 @@ namespace Smash_Forge
             }
         }
     }
-	
+    
     public class Sphere : LVDEntry
     {
-		public override string magic { get { return "030401017735BB7500000002"; } }
+        public override string magic { get { return "030401017735BB7500000002"; } }
         public float x;
         public float y;
         public float z;
@@ -628,8 +628,8 @@ namespace Smash_Forge
         {
             FileData f = new FileData(filename);
             f.skip(0xA);//It's magic
-			
-			f.skip(1);
+            
+            f.skip(1);
             int collisionCount = f.readInt();
             for (int i = 0; i < collisionCount; i++)
             {
@@ -637,7 +637,7 @@ namespace Smash_Forge
                 temp.read(f);
                 collisions.Add(temp);
             }
-			
+            
             f.skip(1);
             int spawnCount = f.readInt();
             for (int i = 0; i < spawnCount; i++)
@@ -646,7 +646,7 @@ namespace Smash_Forge
                 temp.read(f);
                 spawns.Add(temp);
             }
-			
+            
             f.skip(1);
             int respawnCount = f.readInt();
             for (int i = 0; i < respawnCount; i++)
@@ -655,7 +655,7 @@ namespace Smash_Forge
                 temp.read(f);
                 respawns.Add(temp);
             }
-			
+            
             f.skip(1);
             int cameraCount = f.readInt();
             for (int i = 0; i < cameraCount; i++)
@@ -664,7 +664,7 @@ namespace Smash_Forge
                 temp.read(f);
                 cameraBounds.Add(temp);
             }
-			
+            
             f.skip(1);
             int blastzoneCount = f.readInt();
             for (int i = 0; i < blastzoneCount; i++)
@@ -673,34 +673,34 @@ namespace Smash_Forge
                 temp.read(f);
                 blastzones.Add(temp);
             }
-			
+            
             f.skip(1);
             if (f.readInt() != 0) //6
                 return;
-				
+                
             f.skip(1);
             if (f.readInt() != 0) //7
                 return;
-			
+            
             f.skip(1);
             int enemyGeneratorCount = f.readInt();
             if (enemyGeneratorCount != 0) //Are these just item spawners?
                 return;
-			
+            
             f.skip(1);
             if (f.readInt() != 0) //9
                 return;
-			
+            
             f.skip(1);
             int fsAreaCamCount = f.readInt();
             if (fsAreaCamCount != 0)
                 return;
-			
+            
             f.skip(1);
             int fsCamLimitCount = f.readInt();
             if (fsCamLimitCount != 0)
                 return;
-			
+            
             f.skip(1);
             int damageShapeCount = f.readInt();
             for(int i=0; i < damageShapeCount; i++)
@@ -745,7 +745,7 @@ namespace Smash_Forge
                     throw new NotImplementedException();
                 }
             }
-			
+            
             f.skip(1);
             int itemCount = f.readInt();
             for(int i = 0; i < itemCount; i++)
@@ -754,14 +754,14 @@ namespace Smash_Forge
                 temp.read(f);
                 items.Add(temp);
             }
-			
+            
             f.skip(1);
             int generalShapeCount = f.readInt();
             for (int i = 0; i < generalShapeCount; i++)
             {
                 int tempOff = f.pos();
                 LVDGeneralShape p = new LVDGeneralShape();
-				f.seek(tempOff);
+                f.seek(tempOff);
                 if (p.type == 1)
                     p = new GeneralPoint();
                 else if (p.type == 3)
@@ -773,7 +773,7 @@ namespace Smash_Forge
                 p.read(f);
                 generalShapes.Add(p);
             }
-			
+            
             f.skip(1);
             int generalPointCount = f.readInt();
             for(int i = 0; i < generalPointCount; i++)
@@ -783,18 +783,18 @@ namespace Smash_Forge
                 generalPoints.Add(temp);
             }
 
-			f.skip(1);
+            f.skip(1);
             if (f.readInt() != 0) //16
                 return; //no clue how to be consistent in reading these so...
-				
+                
             f.skip(1);
             if (f.readInt() != 0) //17
                 return; //no clue how to be consistent in reading these so...
-				
+                
             f.skip(1);
             if (f.readInt() != 0) //18
                 return; //no clue how to be consistent in reading these so...
-			
+            
             f.skip(1);
             if (f.readInt() != 0) //19
                 return; //no clue how to be consistent in reading these so...
@@ -808,31 +808,31 @@ namespace Smash_Forge
             f.Endian = Endianness.Big;
 
             f.writeHex("000000010A014C564431");
-			
-			f.writeByte(1);
+            
+            f.writeByte(1);
             f.writeInt(collisions.Count);
             foreach (Collision c in collisions)
                 c.save(f);
-			
+            
             f.writeByte(1);
             f.writeInt(spawns.Count);
             foreach (Spawn s in spawns)
                 s.save(f);
-			
+            
             f.writeByte(1);
             f.writeInt(spawns.Count);
             foreach (Spawn s in respawns)
                 s.save(f);
-			
+            
             f.writeByte(1);
             f.writeInt(cameraBounds.Count);
             foreach (Bounds b in cameraBounds)
                 b.save(f);
-			
+            
             f.writeByte(1);
             f.writeInt(blastzones.Count);
             foreach (Bounds b in blastzones)
-				b.save(f);
+                b.save(f);
 
             for (int i = 0; i < 7; i++)
             {

--- a/Smash Forge/Filetypes/Melee/DAT.cs
+++ b/Smash Forge/Filetypes/Melee/DAT.cs
@@ -957,7 +957,7 @@ namespace Smash_Forge
                         int temp = d.pos();
                         if (!dat.jobjOffsetLinker.ContainsKey(jPointer))
                         {
-							d.seek(jPointer);
+                            d.seek(jPointer);
                             JOBJ j = new JOBJ();
                             j.Read(d, dat, node);
                         }

--- a/Smash Forge/Filetypes/Melee/DAT.cs
+++ b/Smash Forge/Filetypes/Melee/DAT.cs
@@ -618,13 +618,13 @@ namespace Smash_Forge
             lvd.cameraBounds.Add(cameraBounds);
             j = 0;
             foreach (Point s in spawns)
-                lvd.spawns.Add(new Point() { x = s.x, y = s.y, name = $"Spawn_{j}", subname = $"{j++}" });
+                lvd.spawns.Add(new Spawn() { x = s.x, y = s.y, name = $"Spawn_{j}", subname = $"{j++}" });
             j = 0;
             foreach (Point s in respawns)
-                lvd.respawns.Add(new Point() { x = s.x, y = s.y, name = $"Respawn_{j}", subname = $"{j++}" });
+                lvd.respawns.Add(new Spawn() { x = s.x, y = s.y, name = $"Respawn_{j}", subname = $"{j++}" });
             j = 0;
             foreach (Point p in itemSpawns)
-                lvd.generalPoints.Add(new Point() { x = p.x, y = p.y, name = $"Item_{j}", subname = $"{j++}" });
+                lvd.generalPoints.Add(new GeneralPoint() { x = p.x, y = p.y, name = $"Item_{j}", subname = $"{j++}" });
 
             /*//This is basically for DSX8 for him quickly converting items in the "dumb" way
             foreach (Vector3 p in itemSpawns)
@@ -785,6 +785,7 @@ namespace Smash_Forge
 
         public class COLL_DATA : LVDEntry
         {
+            public override string magic { get { return "030401017735BB7500000002"; } }
             public class Link
             {
                 public int[] vertexIndices;

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
@@ -29,7 +29,7 @@ namespace Smash_Forge
         private Vector2D currentNormal;
         private CollisionMat currentMat;
         private TreeNode currentTreeNode;
-        private Point currentPoint;
+        private Spawn currentPoint;
         private Bounds currentBounds;
         private Section currentItemSection;
         private GeneralPoint currentGeneralPoint;
@@ -81,27 +81,30 @@ namespace Smash_Forge
                 LVDEntry entry = (LVDEntry)obj;
                 currentTreeNode = entryTree;
                 currentEntry = entry;
+                
+                //These need implementation in the ui for all objects, not just collisions
                 name.Text = currentEntry.name;
                 subname.Text = currentEntry.subname;
+                xStart.Value = (decimal)currentEntry.startPos[0];
+                yStart.Value = (decimal)currentEntry.startPos[1];
+                zStart.Value = (decimal)currentEntry.startPos[2];
+                flag1.Checked = currentEntry.useStartPos;
+                string boneNameRigging = "";
+                foreach (char b in currentEntry.boneName)
+                    if (b != (char)0)
+                        boneNameRigging += b;
+                if (boneNameRigging.Length == 0)
+                    boneNameRigging = "None";
+                button3.Text = boneNameRigging;
+                
                 if (entry is Collision)
                 {
                     Collision col = (Collision)entry;
                     collisionGroup.Visible = true;
-                    xStart.Value = (decimal)col.startPos[0];
-                    yStart.Value = (decimal)col.startPos[1];
-                    zStart.Value = (decimal)col.startPos[2];
-                    flag1.Checked = col.useStartPos;
                     flag2.Checked = col.flag2;
                     flag3.Checked = col.flag3;
                     flag4.Checked = col.flag4;
                     vertices.Nodes.Clear();
-                    string boneNameRigging = "";
-                    foreach (char b in col.unk4)
-                        if (b != (char)0)
-                            boneNameRigging += b;
-                    if (boneNameRigging.Length == 0)
-                        boneNameRigging = "None";
-                    button3.Text = boneNameRigging;
                     for (int i = 0; i < col.verts.Count; i++)
                         vertices.Nodes.Add(new TreeNode($"Vertex {i + 1} ({col.verts[i].x},{col.verts[i].y})") { Tag = col.verts[i] });
                     lines.Nodes.Clear();
@@ -111,12 +114,12 @@ namespace Smash_Forge
                         lines.Nodes.Add(new TreeNode($"Line {i + 1}") { Tag = temp });
                     }
                 }
-                else if (entry is Point)
+                else if (entry is Spawn)
                 {
                     pointGroup.Visible = true;
-                    currentPoint = (Point)entry;
-                    xPoint.Value = (decimal)((Point)entry).x;
-                    yPoint.Value = (decimal)((Point)entry).y;
+                    currentPoint = (Spawn)entry;
+                    xPoint.Value = (decimal)((Spawn)entry).x;
+                    yPoint.Value = (decimal)((Spawn)entry).y;
                 }
                 else if (entry is Bounds)
                 {
@@ -143,7 +146,7 @@ namespace Smash_Forge
                     GeneralPoint p = (GeneralPoint)entry;
                     currentGeneralPoint = p;
                     pointShapeX.Value = (Decimal)p.x;
-                    pointShapeX.Value = (Decimal)p.y;
+                    pointShapeY.Value = (Decimal)p.y;
                 }
                 else if (entry is GeneralRect)
                 {
@@ -217,7 +220,7 @@ namespace Smash_Forge
         private void flagChange(object sender, EventArgs e)
         {
             if(sender == flag1)
-                ((Collision)currentEntry).useStartPos = flag1.Checked;
+                currentEntry.useStartPos = flag1.Checked;
             if (sender == flag2)
                 ((Collision)currentEntry).flag2 = flag2.Checked;
             if (sender == flag3)
@@ -264,11 +267,11 @@ namespace Smash_Forge
         private void changeStart(object sender, EventArgs e)
         {
             if (sender == xStart)
-                ((Collision)currentEntry).startPos[0] = (float)xStart.Value;
+                currentEntry.startPos[0] = (float)xStart.Value;
             if (sender == yStart)
-                ((Collision)currentEntry).startPos[1] = (float)yStart.Value;
+                currentEntry.startPos[1] = (float)yStart.Value;
             if (sender == zStart)
-                ((Collision)currentEntry).startPos[2] = (float)zStart.Value;
+                currentEntry.startPos[2] = (float)zStart.Value;
         }
 
         private void lineFlagChange(object sender, EventArgs e)
@@ -388,12 +391,12 @@ namespace Smash_Forge
         private void button3_Click(object sender, EventArgs e)
         {
             //Open bone selector for collision rigging
-            StringWrapper str = new StringWrapper() { data = ((Collision) currentEntry).unk4 };
+            StringWrapper str = new StringWrapper() { data = currentEntry.boneName };
             BoneRiggingSelector bs = new BoneRiggingSelector(str);
             bs.ShowDialog();
-            ((Collision)currentEntry).unk4 = str.data;
+            currentEntry.boneName = str.data;
             string boneNameRigging = "";
-            foreach (char b in ((Collision)currentEntry).unk4)
+            foreach (char b in currentEntry.boneName)
                 if (b != (char)0)
                     boneNameRigging += b;
             if (boneNameRigging.Length == 0)

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
@@ -59,12 +59,12 @@ namespace Smash_Forge
                     collisionNode.Nodes.Add(new TreeNode(c.name) { Tag = c });
                 }
 
-                foreach (Point c in Runtime.TargetLVD.spawns)
+                foreach (Spawn c in Runtime.TargetLVD.spawns)
                 {
                     spawnNode.Nodes.Add(new TreeNode(c.name) { Tag = c });
                 }
 
-                foreach (Point c in Runtime.TargetLVD.respawns)
+                foreach (Spawn c in Runtime.TargetLVD.respawns)
                 {
                     respawnNode.Nodes.Add(new TreeNode(c.name) { Tag = c });
                 }
@@ -84,7 +84,7 @@ namespace Smash_Forge
                     itemNode.Nodes.Add(new TreeNode(c.name) { Tag = c });
                 }
 
-                foreach (Point c in Runtime.TargetLVD.generalPoints)
+                foreach (GeneralPoint c in Runtime.TargetLVD.generalPoints)
                 {
                     pointNode.Nodes.Add(new TreeNode(c.name) { Tag = c });
                 }
@@ -131,11 +131,10 @@ namespace Smash_Forge
                     Runtime.TargetLVD.blastzones.Remove((Bounds)entry);
                     Runtime.TargetLVD.cameraBounds.Remove((Bounds)entry);
                 }
-                if (entry is Point)
+                if (entry is Spawn)
                 {
-                    Runtime.TargetLVD.generalPoints.Remove((Point)entry);
-                    Runtime.TargetLVD.respawns.Remove((Point)entry);
-                    Runtime.TargetLVD.spawns.Remove((Point)entry);
+                    Runtime.TargetLVD.respawns.Remove((Spawn)entry);
+                    Runtime.TargetLVD.spawns.Remove((Spawn)entry);
                 }
                 if (entry is Collision)
                     Runtime.TargetLVD.collisions.Remove((Collision)entry);
@@ -149,8 +148,8 @@ namespace Smash_Forge
                     Runtime.TargetLVD.generalShapes.Remove((LVDGeneralShape)entry);
                 if (entry is ItemSpawner)
                     Runtime.TargetLVD.items.Remove((ItemSpawner)entry);
-                if (entry is LVDGeneralShape)
-                    Runtime.TargetLVD.generalShapes.Remove((LVDGeneralShape)entry);
+                if (entry is GeneralPoint)
+                    Runtime.TargetLVD.generalPoints.Remove((GeneralPoint)entry);
 
                 treeView1.Nodes.Remove(treeView1.SelectedNode);
             }

--- a/Smash Forge/GUI/Editors/VBNViewport.cs
+++ b/Smash Forge/GUI/Editors/VBNViewport.cs
@@ -1212,11 +1212,17 @@ namespace Smash_Forge
 
                 if (m.dat_melee != null && m.dat_melee.respawns != null)
                     foreach (Point r in m.dat_melee.respawns)
-                        LVD.DrawSpawn(r, true);
+                    {
+                        Spawn temp = new Spawn() { x = r.x, y = r.y };
+                        LVD.DrawSpawn(temp, true);
+                    }
 
                 if (m.dat_melee != null && m.dat_melee.spawns != null)
                     foreach (Point r in m.dat_melee.spawns)
-                        LVD.DrawSpawn(r, false);
+                    {
+                        Spawn temp = new Spawn() { x = r.x, y = r.y };
+                        LVD.DrawSpawn(temp, false);
+                    }
 
                 GL.Color4(Color.FromArgb(200, Color.Fuchsia));
                 if (m.dat_melee != null && m.dat_melee.itemSpawns != null)
@@ -1238,7 +1244,7 @@ namespace Smash_Forge
 
                 if (Runtime.renderSpawns)
                 {
-                    foreach (Point s in Runtime.TargetLVD.spawns)
+                    foreach (Spawn s in Runtime.TargetLVD.spawns)
                     {
                         LVD.DrawSpawn(s, false);
                     }
@@ -1246,7 +1252,7 @@ namespace Smash_Forge
 
                 if (Runtime.renderRespawns)
                 {
-                    foreach (Point s in Runtime.TargetLVD.respawns)
+                    foreach (Spawn s in Runtime.TargetLVD.respawns)
                     {
                         LVD.DrawSpawn(s,true);
                     }
@@ -1254,7 +1260,7 @@ namespace Smash_Forge
 
                 if (Runtime.renderGeneralPoints)
                 {
-                    foreach (Point g in Runtime.TargetLVD.generalPoints)
+                    foreach (GeneralPoint g in Runtime.TargetLVD.generalPoints)
                     {
                         GL.Color4(Color.FromArgb(200, Color.Fuchsia));
                         RenderTools.drawCubeWireframe(new Vector3(g.x, g.y, 0), 3);

--- a/Smash Forge/GUI/MainForm.cs
+++ b/Smash Forge/GUI/MainForm.cs
@@ -924,7 +924,7 @@ namespace Smash_Forge
         {
             if (Runtime.TargetLVD == null)
                 Runtime.TargetLVD = new LVD();
-            Runtime.TargetLVD.spawns.Add(new Point() { name = "START_00_NEW", subname = "00_NEW" });
+            Runtime.TargetLVD.spawns.Add(new Spawn() { name = "START_00_NEW", subname = "00_NEW" });
             lvdList.fillList();
 
         }
@@ -933,7 +933,7 @@ namespace Smash_Forge
         {
             if (Runtime.TargetLVD == null)
                 Runtime.TargetLVD = new LVD();
-            Runtime.TargetLVD.respawns.Add(new Point() { name = "RESTART_00_NEW", subname = "00_NEW" });
+            Runtime.TargetLVD.respawns.Add(new Spawn() { name = "RESTART_00_NEW", subname = "00_NEW" });
             lvdList.fillList();
         }
 
@@ -966,7 +966,7 @@ namespace Smash_Forge
         {
             if (Runtime.TargetLVD == null)
                 Runtime.TargetLVD = new LVD();
-            Runtime.TargetLVD.generalPoints.Add(new Point() { name = "POINT_00_NEW", subname = "00_NEW" });
+            Runtime.TargetLVD.generalPoints.Add(new GeneralPoint() { name = "POINT_00_NEW", subname = "00_NEW" });
             lvdList.fillList();
         }
 

--- a/Smash Forge/param_labels/Render_Param.ini
+++ b/Smash Forge/param_labels/Render_Param.ini
@@ -170,19 +170,20 @@ name=Bloom Intensity?
 group=4
 entry=0
 value=2
-name=Unk1
+name=Bloom effect intensity
+desc=Intensity of the bloom effect on bloomable objects (ones in front of the bloom)
 
 [Value]
 group=4
 entry=0
 value=3
-name=Bloom Max Draw Distance?
+name=Bloom outer size
 
 [Value]
 group=4
 entry=0
 value=4
-name=Bloom Min Draw Distance?
+name=Bloom inner size
 
 [Value]
 group=4
@@ -206,19 +207,19 @@ name=Z Position
 group=4
 entry=0
 value=8
-name=R Color Value?
+name=Red
 
 [Value]
 group=4
 entry=0
 value=9
-name=G Color Value?
+name=Green
 
 [Value]
 group=4
 entry=0
 value=10
-name=B Color Value?
+name=Blue
 
 [Value]
 group=4

--- a/Smash Forge/param_labels/crazy_side_param.ini
+++ b/Smash Forge/param_labels/crazy_side_param.ini
@@ -1,0 +1,197 @@
+name=crazy_side_param
+[Group]
+group=1
+name=Miscellaneous
+
+[Value]
+group=1
+value=0
+name=Entry cost (Gold)
+[Value]
+group=1
+value=1
+name=Entry cost (Crazy Orders Passes)
+[Value]
+group=1
+value=2
+name=Frames of deducting Gold
+[Value]
+group=1
+value=3
+name=Frames of deducting Crazy Orders Passes
+[Value]
+group=1
+value=4
+name=Frames after ticket selection
+[Value]
+group=1
+value=5
+name=Time limit
+desc=The time limit on the mode, in minutes.
+
+[Group]
+group=2
+name=Turn number color
+
+[Entry]
+group=2
+entry=0
+name=Key 1
+[Entry]
+group=2
+entry=1
+name=Key 2
+[Entry]
+group=2
+entry=2
+name=Key 3
+[Entry]
+group=2
+entry=3
+name=Key 4
+[Entry]
+group=2
+entry=4
+name=Key 5
+[Entry]
+group=2
+entry=5
+name=Key 6
+[Entry]
+group=2
+entry=6
+name=Key 7
+
+[Value]
+group=2
+value=0
+name=Turn number
+[Value]
+group=2
+value=1
+name=Red
+[Value]
+group=2
+value=2
+name=Green
+[Value]
+group=2
+value=3
+name=Blue
+[Value]
+group=2
+value=4
+name=Alpha(?)
+[Value]
+group=2
+value=5
+name=Outline color: Red
+[Value]
+group=2
+value=6
+name=Outline color: Green
+[Value]
+group=2
+value=7
+name=Outline color: Blue
+[Value]
+group=2
+value=8
+name=Outline color: Alpha(?)
+
+[Group]
+group=3
+name=Post-battle healing
+
+[Entry]
+group=3
+entry=0
+name=Heal
+[Entry]
+group=3
+entry=1
+name=Heal
+
+[Value]
+group=3
+value=0
+name=Percentage to heal
+desc=After battle, the percentage (not damage amount) to heal of the player's current damage amount. E.g. setting to 50 will heal half of the player's damage
+
+[Group]
+group=4
+name=Omega form odds
+
+[Entry]
+group=4
+entry=0
+name=Main chance
+
+[Value]
+group=4
+value=0
+name=Chance of non-omega form
+[Value]
+group=4
+value=1
+name=Chance of omega form
+
+[Group]
+group=5
+name=Large stage odds
+
+[Entry]
+group=5
+entry=0
+name=Main chance
+
+[Value]
+group=5
+value=0
+name=Chance of standard stage
+[Value]
+group=5
+value=1
+name=Chance of large stage
+
+[Group]
+group=26
+name=Gold reward
+
+[Entry]
+group=26
+entry=0
+name=Key 1
+[Entry]
+group=26
+entry=1
+name=Key 2
+[Entry]
+group=26
+entry=2
+name=Key 3
+[Entry]
+group=26
+entry=3
+name=Key 4
+[Entry]
+group=26
+entry=4
+name=Key 5
+[Entry]
+group=26
+entry=5
+name=Key 6
+
+[Value]
+group=26
+value=0
+name=Turn number
+[Value]
+group=26
+value=1
+name=Minimum gold amount
+[Value]
+group=26
+value=2
+name=Maximum gold amount

--- a/Smash Forge/param_labels/item_stage_gen_param.ini
+++ b/Smash Forge/param_labels/item_stage_gen_param.ini
@@ -2,13 +2,58 @@
 group=2
 name=Item Spawns
 
+[Value]
+group=2
+value=0
+name=Item ID
+
+[Value]
+group=2
+value=1
+name=Costume
+
+[Value]
+group=2
+value=2
+name=Spawn Frequency
+
+[Value]
+group=2
+value=3
+name=Start Action
+
+[Value]
+group=2
+value=4
+name=Start Subaction
+
 [Group]
 group=3
-name=Pokeball Spawns
+name=Poké Ball Spawns
+
+[Value]
+group=3
+value=0
+name=Item ID
+
+[Value]
+group=3
+value=2
+name=Spawn Frequency
 
 [Group]
 group=4
-name=Masterball Spawns
+name=Master Ball Spawns
+
+[Value]
+group=4
+value=0
+name=Item ID
+
+[Value]
+group=4
+value=2
+name=Spawn Frequency
 
 [Entry]
 group=2
@@ -23,7 +68,7 @@ name=Barrel
 [Entry]
 group=2
 entry=2
-name=Box
+name=Crate
 
 [Entry]
 group=2
@@ -48,12 +93,12 @@ name=Party Ball
 [Entry]
 group=2
 entry=7
-name=Masterball
+name=Master Ball
 
 [Entry]
 group=2
 entry=8
-name=Pokeball
+name=Poké Ball
 
 [Entry]
 group=2
@@ -73,7 +118,7 @@ name=Heart Container
 [Entry]
 group=2
 entry=12
-name=Maximum Tomato
+name=Maxim Tomato
 
 [Entry]
 group=2
@@ -83,7 +128,7 @@ name=Food
 [Entry]
 group=2
 entry=14
-name=Spicy Curry
+name=Superspicy Curry
 
 [Entry]
 group=2
@@ -108,12 +153,12 @@ name=Timer
 [Entry]
 group=2
 entry=19
-name=Starman
+name=Super Star
 
 [Entry]
 group=2
 entry=20
-name=Lightning
+name=Lightning Bolt
 
 [Entry]
 group=2
@@ -123,7 +168,7 @@ name=Warp Star
 [Entry]
 group=2
 entry=22
-name=Drill Arm
+name=Drill
 
 [Entry]
 group=2
@@ -178,12 +223,12 @@ name=Hammer
 [Entry]
 group=2
 entry=33
-name=Homerun Bat
+name=Home-Run Bat
 
 [Entry]
 group=2
 entry=34
-name=Lips Stick
+name=Lip's Stick
 
 [Entry]
 group=2
@@ -193,7 +238,7 @@ name=Star Rod
 [Entry]
 group=2
 entry=36
-name=Bannana Peel
+name=Banana Peel
 
 [Entry]
 group=2
@@ -203,22 +248,22 @@ name=Beetle
 [Entry]
 group=2
 entry=38
-name=Bomb-omb
+name=Bob-omb
 
 [Entry]
 group=2
 entry=39
-name=Bombachu
+name=Bombchu
 
 [Entry]
 group=2
 entry=40
-name=Boomarang
+name=Boomerang
 
 [Entry]
 group=2
 entry=41
-name=Galaga Boss
+name=Boss Galaga
 
 [Entry]
 group=2
@@ -243,7 +288,7 @@ name=Deku Nut
 [Entry]
 group=2
 entry=46
-name=Hocotate Ship
+name=Hocotate Bomb
 
 [Entry]
 group=2
@@ -263,22 +308,22 @@ name=Green Shell
 [Entry]
 group=2
 entry=50
-name=Bee Hive
+name=Beehive
 
 [Entry]
 group=2
 entry=51
-name=Eye Turret
+name=Killer Eye
 
 [Entry]
 group=2
 entry=52
-name=Hot Head
+name=Hothead
 
 [Entry]
 group=2
 entry=53
-name=Pitfall Seed
+name=Pitfall
 
 [Entry]
 group=2
@@ -288,7 +333,7 @@ name=POW Block
 [Entry]
 group=2
 entry=55
-name=Motion Sensor Bomb
+name=Motion-Sensor Bomb
 
 [Entry]
 group=2
@@ -313,7 +358,7 @@ name=Team Healer
 [Entry]
 group=2
 entry=60
-name=Blue Shell
+name=Spiny Shell
 
 [Entry]
 group=2
@@ -323,12 +368,12 @@ name=Back Shield
 [Entry]
 group=2
 entry=62
-name=Mother Badge
+name=Franklin Badge
 
 [Entry]
 group=2
 entry=63
-name=Jetpack
+name=Rocket Belt
 
 [Entry]
 group=2
@@ -353,22 +398,22 @@ name=Soccer Ball
 [Entry]
 group=2
 entry=68
-name=Urina
+name=Unira
 
 [Entry]
 group=2
 entry=69
-name=Cuccoo
+name=Cucco
 
 [Entry]
 group=2
 entry=70
-name=Dragoon Piece
+name=Dragoon pieces
 
 [Entry]
 group=2
 entry=71
-name=Daybreak Piece
+name=Daybreak pieces
 
 [Entry]
 group=2
@@ -388,7 +433,7 @@ name=Smash Ball
 [Entry]
 group=2
 entry=75
-name=S Flag
+name=Special Flag
 
 [Entry]
 group=3
@@ -689,33 +734,3 @@ name=Goldeen
 group=4
 entry=19
 name=Xerneas
-
-[Value]
-group=2
-value=0
-name=Item ID
-
-[Value]
-group=2
-value=2
-name=Spawn Rate
-
-[Value]
-group=3
-value=0
-name=Item ID
-
-[Value]
-group=3
-value=2
-name=Spawn Rate
-
-[Value]
-group=4
-value=0
-name=Item ID
-
-[Value]
-group=4
-value=2
-name=Spawn Rate

--- a/Smash Forge/param_labels/ui_movie_db.ini
+++ b/Smash Forge/param_labels/ui_movie_db.ini
@@ -2,361 +2,16 @@
 group=1
 name=Movies
 
-[Entry]
+[Value]
 group=1
-entry=0
-name=Opening
-
-[Entry]
-group=1
-entry=1
-name=How to Play
-
-[Entry]
-group=1
-entry=2
-name=E3 2014 Trailer (Villager Announcement)
-
-[Entry]
-group=1
-entry=3
-name=Mega Man Announcement
-
-[Entry]
-group=1
-entry=4
-name=Wii Fit Trainer Announcement
-
-[Entry]
-group=1
-entry=5
-name=Rosalina Announcement
-
-[Entry]
-group=1
-entry=6
-name=Little Mac Announcement
-
-[Entry]
-group=1
-entry=7
-name=Greninja Announcement
-
-[Entry]
-group=1
-entry=8
-name=Palutena Announcement
-
-[Entry]
-group=1
-entry=9
-name=Pac-Man Announcement
-
-[Entry]
-group=1
-entry=10
-name=Robin/Lucina Announcement
-
-[Entry]
-group=1
-entry=11
-name=Shulk Announcement
-
-[Entry]
-group=1
-entry=12
-name=Bowser Jr. Announcement
-
-[Entry]
-group=1
-entry=13
-name=Duck Hunt Announcement
-
-[Entry]
-group=1
-entry=14
-name=Ending: Mario
-
-[Entry]
-group=1
-entry=15
-name=Ending: Donkey Kong
-
-[Entry]
-group=1
-entry=16
-name=Ending: Link
-
-[Entry]
-group=1
-entry=17
-name=Ending: Samus
-
-[Entry]
-group=1
-entry=18
-name=Ending: Yoshi
-
-[Entry]
-group=1
-entry=19
-name=Ending: Kirby
-
-[Entry]
-group=1
-entry=20
-name=Ending: Fox
-
-[Entry]
-group=1
-entry=21
-name=Ending: Pikachu
-
-[Entry]
-group=1
-entry=22
-name=Ending: Luigi
-
-[Entry]
-group=1
-entry=23
-name=Ending: Captain Falcon
-
-[Entry]
-group=1
-entry=24
-name=Ending: Peach
-
-[Entry]
-group=1
-entry=25
-name=Ending: Bowser
-
-[Entry]
-group=1
-entry=26
-name=Ending: Zelda
-
-[Entry]
-group=1
-entry=27
-name=Ending: Sheik
-
-[Entry]
-group=1
-entry=28
-name=Ending: Marth
-
-[Entry]
-group=1
-entry=29
-name=Ending: Meta Knight
-
-[Entry]
-group=1
-entry=30
-name=Ending: Pit
-
-[Entry]
-group=1
-entry=31
-name=Ending: Zero Suit Samus
-
-[Entry]
-group=1
-entry=32
-name=Ending: Ike
-
-[Entry]
-group=1
-entry=33
-name=Ending: Charizard
-
-[Entry]
-group=1
-entry=34
-name=Ending: Diddy Kong
-
-[Entry]
-group=1
-entry=35
-name=Ending: King Dedede
-
-[Entry]
-group=1
-entry=36
-name=Ending: Olimar
-
-[Entry]
-group=1
-entry=37
-name=Ending: Lucario
-
-[Entry]
-group=1
-entry=38
-name=Ending: Toon Link
-
-[Entry]
-group=1
-entry=39
-name=Ending: Villager
-
-[Entry]
-group=1
-entry=40
-name=Ending: Wii Fit Trainer
-
-[Entry]
-group=1
-entry=41
-name=Ending: Rosalina and Luma
-
-[Entry]
-group=1
-entry=42
-name=Ending: Little Mac
-
-[Entry]
-group=1
-entry=43
-name=Ending: Greninja
-
-[Entry]
-group=1
-entry=44
-name=Ending: Palutena
-
-[Entry]
-group=1
-entry=45
-name=Ending: Robin 
-
-[Entry]
-group=1
-entry=46
-name=Ending: Shulk
-
-[Entry]
-group=1
-entry=47
-name=Ending: Sonic
-
-[Entry]
-group=1
-entry=48
-name=Ending: Mega Man
-
-[Entry]
-group=1
-entry=49
-name=Ending: Pac-Man
-
-[Entry]
-group=1
-entry=50
-name=Ending: Mii Fighter
-
-[Entry]
-group=1
-entry=51
-name=Ending: Ness
-
-[Entry]
-group=1
-entry=52
-name=Ending: Jigglypuff
-
-[Entry]
-group=1
-entry=53
-name=Ending: Falco
-
-[Entry]
-group=1
-entry=54
-name=Ending: Ganondorf
-
-[Entry]
-group=1
-entry=55
-name=Ending: Mr. Game and Watch
-
-[Entry]
-group=1
-entry=56
-name=Ending: Wario
-
-[Entry]
-group=1
-entry=57
-name=Ending: R.O.B.
-
-[Entry]
-group=1
-entry=58
-name=Ending: Duck Hunt
-
-[Entry]
-group=1
-entry=59
-name=Ending: Bowser Jr.
-
-[Entry]
-group=1
-entry=60
-name=Ending: Dr. Mario
-
-[Entry]
-group=1
-entry=61
-name=Ending: Lucina
-
-[Entry]
-group=1
-entry=62
-name=Ending: Dark Pit
-
-[Entry]
-group=1
-entry=63
-name=Ending: Mewtwo
-
-[Entry]
-group=1
-entry=64
-name=Ending: Ryu
-
-[Entry]
-group=1
-entry=65
-name=Ending: Lucas
-
-[Entry]
-group=1
-entry=66
-name=Ending: Roy
-
-[Entry]
-group=1
-entry=67
-name=Ending: Cloud
-
-[Entry]
-group=1
-entry=68
-name=Ending: Bayonetta
-
-[Entry]
-group=1
-entry=69
-name=Ending: Corrin
+value=0
+name=Movie ID
 
 [Value]
 group=1
 value=1
-name=DLC Movie? 
-desc=1 for Yes, 0 for No
+name=Is DLC Movie
+desc=0: No, 1: Yes
 
 [Value]
 group=1
@@ -366,9 +21,300 @@ name=Associated Character ID
 [Value]
 group=1
 value=3
-name=Time (in seconds)
+name=Displayed duration (seconds)
 
 [Value]
 group=1
 value=5
 name=Name in menu.msbt file
+
+[Value]
+group=1
+value=6
+name=Duration as opening movie (frames)
+
+[Value]
+group=1
+value=7
+name=Duration during playback in Vault (frames)
+
+[Entry]
+group=1
+entry=0
+name=Opening
+[Entry]
+group=1
+entry=1
+name=How to Play
+[Entry]
+group=1
+entry=2
+name=E3 2014 Trailer (Villager Announcement)
+[Entry]
+group=1
+entry=3
+name=Mega Man Announcement
+[Entry]
+group=1
+entry=4
+name=Wii Fit Trainer Announcement
+[Entry]
+group=1
+entry=5
+name=Rosalina Announcement
+[Entry]
+group=1
+entry=6
+name=Little Mac Announcement
+[Entry]
+group=1
+entry=7
+name=Greninja Announcement
+[Entry]
+group=1
+entry=8
+name=Palutena Announcement
+[Entry]
+group=1
+entry=9
+name=Pac-Man Announcement
+[Entry]
+group=1
+entry=10
+name=Robin/Lucina Announcement
+[Entry]
+group=1
+entry=11
+name=Shulk Announcement
+[Entry]
+group=1
+entry=12
+name=Bowser Jr. Announcement
+[Entry]
+group=1
+entry=13
+name=Duck Hunt Announcement
+[Entry]
+group=1
+entry=14
+name=Ending: Mario
+[Entry]
+group=1
+entry=15
+name=Ending: Donkey Kong
+[Entry]
+group=1
+entry=16
+name=Ending: Link
+[Entry]
+group=1
+entry=17
+name=Ending: Samus
+[Entry]
+group=1
+entry=18
+name=Ending: Yoshi
+[Entry]
+group=1
+entry=19
+name=Ending: Kirby
+[Entry]
+group=1
+entry=20
+name=Ending: Fox
+[Entry]
+group=1
+entry=21
+name=Ending: Pikachu
+[Entry]
+group=1
+entry=22
+name=Ending: Luigi
+[Entry]
+group=1
+entry=23
+name=Ending: Captain Falcon
+[Entry]
+group=1
+entry=24
+name=Ending: Peach
+[Entry]
+group=1
+entry=25
+name=Ending: Bowser
+[Entry]
+group=1
+entry=26
+name=Ending: Zelda
+[Entry]
+group=1
+entry=27
+name=Ending: Sheik
+[Entry]
+group=1
+entry=28
+name=Ending: Marth
+[Entry]
+group=1
+entry=29
+name=Ending: Meta Knight
+[Entry]
+group=1
+entry=30
+name=Ending: Pit
+[Entry]
+group=1
+entry=31
+name=Ending: Zero Suit Samus
+[Entry]
+group=1
+entry=32
+name=Ending: Ike
+[Entry]
+group=1
+entry=33
+name=Ending: Charizard
+[Entry]
+group=1
+entry=34
+name=Ending: Diddy Kong
+[Entry]
+group=1
+entry=35
+name=Ending: King Dedede
+[Entry]
+group=1
+entry=36
+name=Ending: Olimar
+[Entry]
+group=1
+entry=37
+name=Ending: Lucario
+[Entry]
+group=1
+entry=38
+name=Ending: Toon Link
+[Entry]
+group=1
+entry=39
+name=Ending: Villager
+[Entry]
+group=1
+entry=40
+name=Ending: Wii Fit Trainer
+[Entry]
+group=1
+entry=41
+name=Ending: Rosalina and Luma
+[Entry]
+group=1
+entry=42
+name=Ending: Little Mac
+[Entry]
+group=1
+entry=43
+name=Ending: Greninja
+[Entry]
+group=1
+entry=44
+name=Ending: Palutena
+[Entry]
+group=1
+entry=45
+name=Ending: Robin 
+[Entry]
+group=1
+entry=46
+name=Ending: Shulk
+[Entry]
+group=1
+entry=47
+name=Ending: Sonic
+[Entry]
+group=1
+entry=48
+name=Ending: Mega Man
+[Entry]
+group=1
+entry=49
+name=Ending: Pac-Man
+[Entry]
+group=1
+entry=50
+name=Ending: Mii Fighter
+[Entry]
+group=1
+entry=51
+name=Ending: Ness
+[Entry]
+group=1
+entry=52
+name=Ending: Jigglypuff
+[Entry]
+group=1
+entry=53
+name=Ending: Falco
+[Entry]
+group=1
+entry=54
+name=Ending: Ganondorf
+[Entry]
+group=1
+entry=55
+name=Ending: Mr. Game and Watch
+[Entry]
+group=1
+entry=56
+name=Ending: Wario
+[Entry]
+group=1
+entry=57
+name=Ending: R.O.B.
+[Entry]
+group=1
+entry=58
+name=Ending: Duck Hunt
+[Entry]
+group=1
+entry=59
+name=Ending: Bowser Jr.
+[Entry]
+group=1
+entry=60
+name=Ending: Dr. Mario
+[Entry]
+group=1
+entry=61
+name=Ending: Lucina
+[Entry]
+group=1
+entry=62
+name=Ending: Dark Pit
+[Entry]
+group=1
+entry=63
+name=Ending: Mewtwo
+[Entry]
+group=1
+entry=64
+name=Ending: Ryu
+[Entry]
+group=1
+entry=65
+name=Ending: Lucas
+[Entry]
+group=1
+entry=66
+name=Ending: Roy
+[Entry]
+group=1
+entry=67
+name=Ending: Cloud
+[Entry]
+group=1
+entry=68
+name=Ending: Bayonetta
+[Entry]
+group=1
+entry=69
+name=Ending: Corrin


### PR DESCRIPTION
I have significantly changed the class definitions and reading of LVD.

- Base class 'LVDEntry' (of which LVD objects derive) is fleshed out to be the base of LVD objects. This enables objects to read/write their bone name and start position (previously only done for collisions).
- Implemented 'CLIFF' objects for collisions. Cliffs are now read and written, but they remain unaccessible in the GUI.
- Separated spawns and respawns to use a separate class, 'Spawn'. General points are now 'GeneralPoint', a derivative of 'LVDGeneralShape'. The 'Point' class remains in order to not break a lot of code that is using it.
- Some general re-organizing and formatting.

I have also added a parameter label .ini file, and modified two others: one for typos and the other for new values.