### PR TITLE
Cleanup for LVD shapes and points, bugfixes

### DIFF
--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -820,7 +820,7 @@ namespace Smash_Forge
                 s.save(f);
             
             f.writeByte(1);
-            f.writeInt(spawns.Count);
+            f.writeInt(respawns.Count);
             foreach (Spawn s in respawns)
                 s.save(f);
             

--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -22,7 +22,7 @@ namespace Smash_Forge
         public bool useStartPos = false;
         public int unk1 = 0;
         public float[] unk2 = new float[3];
-        public int unk3 = 0;
+        public int unk3 = unchecked((int)0xFFFFFFFF);
         public char[] boneName = new char[0x40];
         
         public void read(FileData f)
@@ -417,28 +417,28 @@ namespace Smash_Forge
         
     }
 
-    public enum shape //I don't think these are accurate
+    public enum shape
     {
         point = 1,
         rectangle = 3,
         path = 4
     }
 
-    public class LVDGeneralShape : LVDEntry
+    public class LVDShape : LVDEntry
     {
         public override string magic { get { return "010401017735BB7500000002"; } }
         
-        public int type;
-
+        public int type; 
+    }
+    
+    public class LVDGeneralShape : LVDShape
+    {
         public void read(FileData f)
         {
             base.read(f);
             
             f.skip(1);
             f.readInt(); //unknown
-            
-            f.skip(1);
-            type = f.readInt();
         }
         public void save(FileOutput f)
         {
@@ -446,85 +446,30 @@ namespace Smash_Forge
             
             f.writeByte(1);
             f.writeInt(0);
-            
-            f.writeByte(1);
-            f.writeInt(type);
         }
     }
-
-    public class GeneralPoint : LVDGeneralShape
-    {
-        public float x, y;
-
-        public GeneralPoint()
-        {
-            type = 1;
-        }
-
-        public void read(FileData f)
-        {
-            base.read(f);
-            
-            x = f.readFloat();
-            y = f.readFloat();
-            f.skip(0x14);
-        }
-        public void save(FileOutput f)
-        {
-            base.save(f);
-            
-            f.writeFloat(x);
-            f.writeFloat(y);
-            f.writeHex("0000000000000000000000000000000000000000");
-        }
-    }
-
-    public class GeneralRect : LVDGeneralShape
+    
+    public class GeneralShape : LVDGeneralShape //GeneralRects and GeneralPaths are both the same object type (this one), their difference is how they are used
     {
         public float x1, y1, x2, y2;
-
-        public GeneralRect()
-        {
-            type = 3;
-        }
-
+        public List<Vector2D> points = new List<Vector2D>();
+        
         public void read(FileData f)
         {
             base.read(f);
-        
+            
+            f.readByte();
+            type = f.readInt(); //3 = rect, 4 = path
+            if ((type != 3) && (type != 4))
+                throw new NotImplementedException($"Unknown general shape type {type} at offset {f.pos()-4}");
+            
             x1 = f.readFloat();
             y1 = f.readFloat();
             x2 = f.readFloat();
             y2 = f.readFloat();
-            f.skip(0x6);
-        }
-
-        public void save(FileOutput f)
-        {
-            base.save(f);
             
-            f.writeFloat(x1);
-            f.writeFloat(y1);
-            f.writeFloat(x2);
-            f.writeFloat(y2);
-            f.writeHex("010100000000");
-        }
-    }
-
-    public class GeneralPath : LVDGeneralShape
-    {
-        public List<Vector2D> points = new List<Vector2D>();
-
-        public GeneralPath()
-        {
-            type = 4;
-        }
-
-        public void read(FileData f)
-        {
-            base.read(f);
-            
-            f.skip(0x12);
+            f.skip(1);
+            f.skip(1);
             int pointCount = f.readInt();
             for(int i = 0; i < pointCount; i++)
             {
@@ -532,14 +477,22 @@ namespace Smash_Forge
                 points.Add(new Vector2D() { x = f.readFloat(), y = f.readFloat() });
             }
         }
-
         public void save(FileOutput f)
         {
             base.save(f);
             
-            f.writeHex("000000000000000000000000000000000101");
+            f.writeByte(0x3);
+            f.writeInt(type);
+            
+            f.writeFloat(x1);
+            f.writeFloat(y1);
+            f.writeFloat(x2);
+            f.writeFloat(y2);
+            
+            f.writeByte(1);
+            f.writeByte(1);
             f.writeInt(points.Count);
-            foreach (Vector2D point in points)
+            foreach(Vector2D point in points)
             {
                 f.writeByte(1);
                 f.writeFloat(point.x);
@@ -548,26 +501,108 @@ namespace Smash_Forge
         }
     }
     
-    public class Sphere : LVDEntry
+    public class GeneralPoint : LVDGeneralShape
     {
-        public override string magic { get { return "030401017735BB7500000002"; } }
-        public float x;
-        public float y;
-        public float z;
-        public float radius;
-    }
+        public float x, y, z;
 
-    public class Capsule : LVDEntry
+        public GeneralPoint()
+        {
+            type = 4;
+        }
+
+        public void read(FileData f)
+        {
+            base.read(f);
+            
+            f.skip(1);
+            type = f.readInt(); //always 4?
+            
+            x = f.readFloat();
+            y = f.readFloat();
+            z = f.readFloat();
+            f.skip(0x10);
+        }
+        public void save(FileOutput f)
+        {
+            base.save(f);
+            
+            f.writeByte(1);
+            f.writeInt(type);
+            
+            f.writeFloat(x);
+            f.writeFloat(y);
+            f.writeFloat(z);
+            f.writeHex("00000000000000000000000000000000");
+        }
+    }
+    
+    public class DamageShape : LVDShape
     {
-        public override string magic { get { return "030401017735BB7500000002"; } }
         public float x;
         public float y;
         public float z;
-        public float r;
         public float dx;
         public float dy;
         public float dz;
+        public float radius;
         public float unk;
+
+        public void read(FileData f)
+        {
+            base.read(f);
+            
+            f.skip(1);
+            type = f.readInt(); //2 = sphere, 3 = capsule
+            if ((type != 2) && (type != 3))
+                throw new NotImplementedException($"Unknown damage shape type {type} at offset {f.pos()-4}");
+            
+            x = f.readFloat();
+            y = f.readFloat();
+            z = f.readFloat();
+            if (type == 2)
+            {
+                radius = f.readFloat();
+                dx = f.readFloat();
+                dy = f.readFloat();
+                dz = f.readFloat();
+            }
+            else if (type == 3)
+            {
+                dx = f.readFloat();
+                dy = f.readFloat();
+                dz = f.readFloat();
+                radius = f.readFloat();
+            }
+            unk = f.readFloat();
+            f.skip(0x1);
+        }
+        public void save(FileOutput f)
+        {
+            base.save(f);
+            
+            f.writeByte(1);
+            f.writeInt(type);
+            
+            f.writeFloat(x);
+            f.writeFloat(y);
+            f.writeFloat(z);
+            if (type == 2)
+            {
+                f.writeFloat(radius);
+                f.writeFloat(dx);
+                f.writeFloat(dy);
+                f.writeFloat(dz);
+            }
+            else if (type == 3)
+            {
+                f.writeFloat(dx);
+                f.writeFloat(dy);
+                f.writeFloat(dz);
+                f.writeFloat(radius);
+            }
+            f.writeFloat(unk);
+            f.writeHex("00");
+        }
     }
 
     public class LVD : FileBase
@@ -579,12 +614,11 @@ namespace Smash_Forge
             respawns = new List<Spawn>();
             cameraBounds = new List<Bounds>();
             blastzones = new List<Bounds>();
-            generalShapes = new List<LVDGeneralShape>();
-            generalPoints = new List<GeneralPoint>();
-            damageSpheres = new List<Sphere>();
-            items = new List<ItemSpawner>();
-            damageCapsules = new List<Capsule>();
             enemySpawns = new List<EnemyGenerator>();
+            damageShapes = new List<DamageShape>();
+            items = new List<ItemSpawner>();
+            generalShapes = new List<GeneralShape>();
+            generalPoints = new List<GeneralPoint>();
         }
         public LVD(string filename) : this()
         {
@@ -595,12 +629,11 @@ namespace Smash_Forge
         public List<Spawn> respawns { get; set; }
         public List<Bounds> cameraBounds { get; set; }
         public List<Bounds> blastzones { get; set; }
-        public List<LVDGeneralShape> generalShapes { get; set; }
-        public List<GeneralPoint> generalPoints { get; set; }
-        public List<Sphere> damageSpheres { get; set; }
-        public List<ItemSpawner> items { get; set; }
-        public List<Capsule> damageCapsules { get; set; }
         public List<EnemyGenerator> enemySpawns { get; set; }
+        public List<DamageShape> damageShapes { get; set; }
+        public List<ItemSpawner> items { get; set; }
+        public List<GeneralShape> generalShapes { get; set; }
+        public List<GeneralPoint> generalPoints { get; set; }
 
         public override Endianness Endian { get; set; }
 
@@ -684,7 +717,7 @@ namespace Smash_Forge
             
             f.skip(1);
             int enemyGeneratorCount = f.readInt();
-            if (enemyGeneratorCount != 0) //Are these just item spawners?
+            if (enemyGeneratorCount != 0) //Can these be read in the same way as item spawners?
                 return;
             
             f.skip(1);
@@ -705,45 +738,9 @@ namespace Smash_Forge
             int damageShapeCount = f.readInt();
             for(int i=0; i < damageShapeCount; i++)
             {
-                f.skip(0xD);
-
-                string tempName = f.readString(f.pos(), 0x38);
-                f.skip(0x38);
-                f.skip(1);
-                string tempSubname = f.readString(f.pos(), 0x40);
-                f.skip(0xA6);
-                int shapeType = f.readInt();
-                if (shapeType == 2) {
-                    Sphere temp = new Sphere();
-                    temp.name = tempName;
-                    temp.subname = tempSubname;
-                    temp.x = f.readFloat();
-                    temp.y = f.readFloat();
-                    temp.z = f.readFloat();
-                    temp.radius = f.readFloat();
-                    f.skip(0x11);
-                    damageSpheres.Add(temp);
-                }
-                else if(shapeType == 3)
-                {
-                    Capsule temp = new Capsule();
-                    temp.name = tempName;
-                    temp.subname = tempSubname;
-                    temp.x = f.readFloat();
-                    temp.y = f.readFloat();
-                    temp.z = f.readFloat();
-                    temp.dx = f.readFloat();
-                    temp.dy = f.readFloat();
-                    temp.dz = f.readFloat();
-                    temp.r = f.readFloat();
-                    temp.unk = f.readFloat();
-                    f.skip(1);
-                    damageCapsules.Add(temp);
-                }
-                else
-                {
-                    throw new NotImplementedException();
-                }
+                DamageShape temp = new DamageShape();
+                temp.read(f);
+                damageShapes.Add(temp);
             }
             
             f.skip(1);
@@ -759,19 +756,9 @@ namespace Smash_Forge
             int generalShapeCount = f.readInt();
             for (int i = 0; i < generalShapeCount; i++)
             {
-                int tempOff = f.pos();
-                LVDGeneralShape p = new LVDGeneralShape();
-                f.seek(tempOff);
-                if (p.type == 1)
-                    p = new GeneralPoint();
-                else if (p.type == 3)
-                    p = new GeneralRect();
-                else if (p.type == 4)
-                    p = new GeneralPath();
-                else
-                    throw new Exception($"Unknown shape type {p.type} at offset {tempOff}");
-                p.read(f);
-                generalShapes.Add(p);
+                GeneralShape temp = new GeneralShape();
+                temp.read(f);
+                generalShapes.Add(temp);
             }
             
             f.skip(1);
@@ -834,12 +821,17 @@ namespace Smash_Forge
             foreach (Bounds b in blastzones)
                 b.save(f);
 
-            for (int i = 0; i < 7; i++)
+            for (int i = 0; i < 6; i++)
             {
                 f.writeByte(1);
                 f.writeInt(0);
             }
 
+            f.writeByte(1);
+            f.writeInt(damageShapes.Count);
+            foreach (DamageShape shape in damageShapes)
+                shape.save(f);
+            
             f.writeByte(1);
             f.writeInt(items.Count);
             foreach (ItemSpawner item in items)
@@ -847,10 +839,9 @@ namespace Smash_Forge
 
             f.writeByte(1);
             f.writeInt(generalShapes.Count);
-            foreach (LVDGeneralShape shape in generalShapes)
+            foreach (GeneralShape shape in generalShapes)
                 shape.save(f);
             
-
             f.writeByte(1);
             f.writeInt(generalPoints.Count);
             foreach (GeneralPoint p in generalPoints)
@@ -948,7 +939,7 @@ namespace Smash_Forge
             GL.End();
         }
 
-        public static void DrawCameraBounds(Bounds b, Color color)
+        public static void DrawBounds(Bounds b, Color color)
         {
             GL.Color4(Color.FromArgb(128, color));
             GL.Begin(PrimitiveType.LineLoop);
@@ -1188,17 +1179,6 @@ namespace Smash_Forge
                 GL.Vertex3(vi.x * scale, vi.y * scale, -5);
                 GL.End();
             }
-        }
-
-        public static void DrawBlastZones(Bounds b, Color color)
-        {
-            GL.Color4(Color.FromArgb(128, color));
-            GL.Begin(PrimitiveType.LineLoop);
-            GL.Vertex3(b.left, b.top, 0);
-            GL.Vertex3(b.right, b.top, 0);
-            GL.Vertex3(b.right, b.bottom, 0);
-            GL.Vertex3(b.left, b.bottom, 0);
-            GL.End();
         }
 
     }

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
@@ -33,8 +33,8 @@ namespace Smash_Forge
         private Bounds currentBounds;
         private Section currentItemSection;
         private GeneralPoint currentGeneralPoint;
-        private GeneralRect currentGeneralRect;
-        private GeneralPath currentGeneralPath;
+        private GeneralShape currentGeneralRect;
+        private GeneralShape currentGeneralPath;
         private DAT.JOBJ currentJobj;
         public DAT datToPrerender = null;
 
@@ -82,7 +82,7 @@ namespace Smash_Forge
                 currentTreeNode = entryTree;
                 currentEntry = entry;
                 
-                //These need implementation in the ui for all objects, not just collisions
+                //These need implementation in the gui for all objects, not just collisions
                 name.Text = currentEntry.name;
                 subname.Text = currentEntry.subname;
                 xStart.Value = (decimal)currentEntry.startPos[0];
@@ -148,25 +148,27 @@ namespace Smash_Forge
                     pointShapeX.Value = (Decimal)p.x;
                     pointShapeY.Value = (Decimal)p.y;
                 }
-                else if (entry is GeneralRect)
+                else if (entry is GeneralShape)
                 {
-                    rectangleGroup.Visible = true;
-                    GeneralRect r = (GeneralRect)entry;
-                    currentGeneralRect = r;
-                    rectUpperX.Value = (Decimal)r.x2;
-                    rectUpperY.Value = (Decimal)r.y2;
-                    rectLowerX.Value = (Decimal)r.x1;
-                    rectLowerY.Value = (Decimal)r.y1;
-                }
-                else if (entry is GeneralPath)
-                {
-                    pathGroup.Visible = true;
-                    GeneralPath p = (GeneralPath)entry;
-                    currentGeneralPath = p;
-                    treeViewPath.Nodes.Clear();
-                    int j = 0;
-                    foreach (Vector2D v in p.points)
-                        treeViewPath.Nodes.Add(new TreeNode($"Point {++j} ({v.x},{v.y})") { Tag = v });
+                    GeneralShape s = (GeneralShape)entry;
+                    if (s.type == 3)
+                    {
+                        rectangleGroup.Visible = true;
+                        currentGeneralRect = s;
+                        rectUpperX.Value = (Decimal)s.x2;
+                        rectUpperY.Value = (Decimal)s.y2;
+                        rectLowerX.Value = (Decimal)s.x1;
+                        rectLowerY.Value = (Decimal)s.y1;
+                    }
+                    else if (s.type == 4)
+                    {
+                        pathGroup.Visible = true;
+                        currentGeneralPath = s;
+                        treeViewPath.Nodes.Clear();
+                        int j = 0;
+                        foreach (Vector2D v in s.points)
+                            treeViewPath.Nodes.Add(new TreeNode($"Point {++j} ({v.x},{v.y})") { Tag = v });
+                    }
                 }
                 else if (entry is DAT.COLL_DATA)
                 {
@@ -499,7 +501,7 @@ namespace Smash_Forge
 
         private void rectValueChanged(object sender, EventArgs e)
         {
-            GeneralRect r = currentGeneralRect;
+            GeneralShape r = currentGeneralRect;
             if(sender == rectUpperX)
                 r.x2 = (float)rectUpperX.Value;
             if (sender == rectUpperY)

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
@@ -89,19 +89,14 @@ namespace Smash_Forge
                     pointNode.Nodes.Add(new TreeNode(c.name) { Tag = c });
                 }
 
-                foreach (LVDGeneralShape s in Runtime.TargetLVD.generalShapes)
+                foreach (GeneralShape s in Runtime.TargetLVD.generalShapes)
                 {
                     shapeNode.Nodes.Add(new TreeNode(s.name) { Tag = s });
                 }
 
-                foreach (Sphere c in Runtime.TargetLVD.damageSpheres)
+                foreach (DamageShape s in Runtime.TargetLVD.damageShapes)
                 {
-                    hurtNode.Nodes.Add(new TreeNode(c.name) { Tag = c });
-                }
-
-                foreach (Capsule c in Runtime.TargetLVD.damageCapsules)
-                {
-                    hurtNode.Nodes.Add(new TreeNode(c.name) { Tag = c });
+                    hurtNode.Nodes.Add(new TreeNode(s.name) { Tag = s });
                 }
 
                 foreach (EnemyGenerator c in Runtime.TargetLVD.enemySpawns)
@@ -138,14 +133,12 @@ namespace Smash_Forge
                 }
                 if (entry is Collision)
                     Runtime.TargetLVD.collisions.Remove((Collision)entry);
-                if (entry is Capsule)
-                    Runtime.TargetLVD.damageCapsules.Remove((Capsule) entry);
-                if (entry is Sphere)
-                    Runtime.TargetLVD.damageSpheres.Remove((Sphere)entry);
+                if (entry is DamageShape)
+                    Runtime.TargetLVD.damageShapes.Remove((DamageShape)entry);
                 if (entry is EnemyGenerator)
                     Runtime.TargetLVD.enemySpawns.Remove((EnemyGenerator)entry);
-                if (entry is LVDGeneralShape)
-                    Runtime.TargetLVD.generalShapes.Remove((LVDGeneralShape)entry);
+                if (entry is GeneralShape)
+                    Runtime.TargetLVD.generalShapes.Remove((GeneralShape)entry);
                 if (entry is ItemSpawner)
                     Runtime.TargetLVD.items.Remove((ItemSpawner)entry);
                 if (entry is GeneralPoint)

--- a/Smash Forge/GUI/Editors/VBNViewport.cs
+++ b/Smash Forge/GUI/Editors/VBNViewport.cs
@@ -1180,12 +1180,12 @@ namespace Smash_Forge
 
                 if (m.dat_melee != null && m.dat_melee.blastzones != null)
                 {
-                    LVD.DrawBlastZones(m.dat_melee.blastzones, Color.Red);
+                    LVD.DrawBounds(m.dat_melee.blastzones, Color.Red);
                 }
 
                 if (m.dat_melee != null && m.dat_melee.cameraBounds != null)
                 {
-                    LVD.DrawCameraBounds(m.dat_melee.cameraBounds, Color.Blue);
+                    LVD.DrawBounds(m.dat_melee.cameraBounds, Color.Blue);
                 }
 
                 if (m.dat_melee != null && m.dat_melee.targets != null)
@@ -1253,17 +1253,17 @@ namespace Smash_Forge
                         RenderTools.drawCubeWireframe(new Vector3(g.x, g.y, 0), 3);
                     }
                     
-                    foreach (LVDGeneralShape shape in Runtime.TargetLVD.generalShapes)
+                    foreach (GeneralShape shape in Runtime.TargetLVD.generalShapes)
                     {
-                        if(shape is GeneralPoint)
+                        /*if(shape is GeneralPoint)
                         {
                             GeneralPoint g = (GeneralPoint)shape;
                             GL.Color4(Color.FromArgb(200, Color.Fuchsia));
                             RenderTools.drawCubeWireframe(new Vector3(g.x, g.y, 0), 3);
-                        }
-                        if(shape is GeneralRect)
+                        }*/
+                        if(shape.type == 3)
                         {
-                            GeneralRect b = (GeneralRect)shape;
+                            GeneralShape b = (GeneralShape)shape;
                             GL.Color4(Color.FromArgb(200, Color.Fuchsia));
                             GL.Begin(PrimitiveType.LineLoop);
                             GL.Vertex3(b.x1, b.y1, 0);
@@ -1272,9 +1272,9 @@ namespace Smash_Forge
                             GL.Vertex3(b.x1, b.y2, 0);
                             GL.End();
                         }
-                        if(shape is GeneralPath)
+                        if(shape.type == 4)
                         {
-                            List<Vector2D> p = ((GeneralPath)shape).points;
+                            List<Vector2D> p = ((GeneralShape)shape).points;
                             GL.Color4(Color.FromArgb(200, Color.Fuchsia));
                             GL.Begin(PrimitiveType.LineStrip);
                             foreach(Vector2D point in p)
@@ -1287,25 +1287,23 @@ namespace Smash_Forge
                 if (Runtime.renderOtherLVDEntries)
                 {
                     GL.Color4(Color.FromArgb(128, Color.Yellow));
-                    foreach (Sphere s in Runtime.TargetLVD.damageSpheres)
+                    foreach (DamageShape s in Runtime.TargetLVD.damageShapes)
                     {
-                        RenderTools.drawSphere(new Vector3(s.x, s.y, s.z), s.radius, 24);
+                        if (s.type == 2)
+                            RenderTools.drawSphere(new Vector3(s.x, s.y, s.z), s.radius, 24);
+                        if (s.type == 3)
+                            RenderTools.drawCylinder(new Vector3(s.x, s.y, s.z), new Vector3(s.x + s.dx, s.y + s.dy, s.z + s.dz), s.radius);
                     }
 
-                    foreach (Capsule c in Runtime.TargetLVD.damageCapsules)
-                    {
-                        RenderTools.drawCylinder(new Vector3(c.x, c.y, c.z), new Vector3(c.x + c.dx, c.y + c.dy, c.z + c.dz), c.r);
-                    }
 
-                  
                     foreach (Bounds b in Runtime.TargetLVD.blastzones)
                     {
-                        LVD.DrawBlastZones(b, Color.Red);
+                        LVD.DrawBounds(b, Color.Red);
                     }
 
                     foreach (Bounds b in Runtime.TargetLVD.cameraBounds)
                     {
-                        LVD.DrawCameraBounds(b, Color.Blue);
+                        LVD.DrawBounds(b, Color.Blue);
                     }
                 }
             }

--- a/Smash Forge/GUI/MainForm.cs
+++ b/Smash Forge/GUI/MainForm.cs
@@ -972,21 +972,23 @@ namespace Smash_Forge
 
         private void pointToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            GeneralPoint g = new GeneralPoint() { name = "POINT_00_NEW", subname = "00_NEW" };
+            return;
+            //Disabled this because I'm implementing general points as separate from general shapes
+            /*GeneralPoint g = new GeneralPoint() { name = "POINT_00_NEW", subname = "00_NEW" };
             Runtime.TargetLVD.generalShapes.Add(g);
-            lvdList.fillList();
+            lvdList.fillList();*/
         }
 
         private void rectangleToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            GeneralRect g = new GeneralRect() { name = "RECT_00_NEW", subname = "00_NEW" };
+            GeneralShape g = new GeneralShape() { name = "RECT_00_NEW", subname = "00_NEW", type = 3 };
             Runtime.TargetLVD.generalShapes.Add(g);
             lvdList.fillList();
         }
 
         private void pathToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            GeneralPath g = new GeneralPath() { name = "PATH_00_NEW", subname = "00_NEW" };
+            GeneralShape g = new GeneralShape() { name = "PATH_00_NEW", subname = "00_NEW", type = 4 };
             Runtime.TargetLVD.generalShapes.Add(g);
             lvdList.fillList();
         }

--- a/Smash Forge/GUI/MainForm.cs
+++ b/Smash Forge/GUI/MainForm.cs
@@ -1633,7 +1633,10 @@ namespace Smash_Forge
 
             if (fileName.EndsWith(".lvd"))
             {
-                Runtime.TargetLVD = new LVD(fileName);
+                if (Runtime.TargetLVD == null)
+                    Runtime.TargetLVD = new LVD(fileName);
+                else
+                    Runtime.TargetLVD.Read(fileName);
                 LVD test = Runtime.TargetLVD;
                 lvdList.fillList();
             }


### PR DESCRIPTION
I have done some more work on LVD, primarily for shapes and points.

- Add new classes to be used by general shapes and damage shapes ('GeneralShape' and 'DamageShape', respectively). The different types of these respective objects can be handled identically in i/o, so they are better off with one object type. Implementations can decide how to handle these objects by their 'type' member, and I have updated existing code to do so.

- Improve reading of general shapes and damage shapes, and add writing to the latter. Damage shapes are no longer lost when saving, however they remain uneditable in the GUI.

- Remove categorization of GeneralPoint as general shapes. Currently, I can find no example of an LVD that has general points in its general shapes. Previously, the general shapes list was allowed to contain general points; I have removed this so only GeneralShape objects can be categorized as such, and general points are now exclusively found in the general points list. I have disabled the button in the GUI which adds a general point to the shapes list (it does nothing now).

- Add z position to be read and written for general points. General points are 3D, so I have updated them to read and write their z position as well. I have not updated the GUI to allow the z position to be accessible for editing.

- Append LVD objects when opening an LVD while there is already LVD data open. Previously, opening an LVD would clear the LVD data, replacing it. Now, it appends the data, allowing merging of objects between LVD files. 'Clear Workspace' will still clear the LVD data properly.

- Remove duplicate bounds-drawing functions. There were previously two methods for this (one for death bounds, one for camera bounds), however this was redundant because they were identical. I have removed the duplicate, and the function is now called 'DrawBounds'.