### PR TITLE
Render LVD cliffs, tweak DAE import option

### DIFF
--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -1129,15 +1129,30 @@ namespace Smash_Forge
                 }
                 for (int i = 0; i < c.cliffs.Count; i++)
                 {
+                    float add2X = 0, add2Y = 0, add2Z = 0;
+                    if (c.cliffs[i].useStartPos)
+                    {
+                        add2X = c.startPos[0];
+                        add2Y = c.startPos[1];
+                        add2Z = c.startPos[2];
+                    }
+                    
+                    Vector3 v1Pos = Vector3.Transform(new Vector3(c.cliffs[i].pos.x + add2X, c.cliffs[i].pos.y + add2Y, add2Z + 10), transform);
+                    Vector3 v1Neg = Vector3.Transform(new Vector3(c.cliffs[i].pos.x + add2X, c.cliffs[i].pos.y + add2Y, add2Z - 10), transform);
+                    Vector3 v1Zer = Vector3.Transform(new Vector3(c.cliffs[i].pos.x + add2X, c.cliffs[i].pos.y + add2Y, add2Z), transform);
+                    
                     GL.Begin(PrimitiveType.Lines);
                     GL.Color4(Color.White);
                     
-                    Vector3 v1Pos = Vector3.Transform(new Vector3(c.cliffs[i].pos.x + addX, c.cliffs[i].pos.y + addY, addZ + 10), transform);
-                    Vector3 v1Neg = Vector3.Transform(new Vector3(c.cliffs[i].pos.x + addX, c.cliffs[i].pos.y + addY, addZ - 10), transform);
-                    
                     GL.Vertex3(v1Pos);
                     GL.Vertex3(v1Neg);
+                    GL.End();
                     
+                    GL.Begin(PrimitiveType.Lines);
+                    GL.Color3(Color.Blue);
+                    
+                    GL.Vertex3(v1Zer);
+                    GL.Vertex3(v1Zer.X + (c.cliffs[i].angle.x * 10), v1Zer.Y + (c.cliffs[i].angle.y * 10), v1Zer.Z);
                     GL.End();
                 }
             }

--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -1127,6 +1127,19 @@ namespace Smash_Forge
                     }
                     GL.End();
                 }
+                for (int i = 0; i < c.cliffs.Count; i++)
+                {
+                    GL.Begin(PrimitiveType.Lines);
+                    GL.Color4(Color.White);
+                    
+                    Vector3 v1Pos = Vector3.Transform(new Vector3(c.cliffs[i].pos.x + addX, c.cliffs[i].pos.y + addY, addZ + 10), transform);
+                    Vector3 v1Neg = Vector3.Transform(new Vector3(c.cliffs[i].pos.x + addX, c.cliffs[i].pos.y + addY, addZ - 10), transform);
+                    
+                    GL.Vertex3(v1Pos);
+                    GL.Vertex3(v1Neg);
+                    
+                    GL.End();
+                }
             }
         }
 

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
@@ -563,6 +563,18 @@ namespace Smash_Forge
         private void button10_Click(object sender, EventArgs e)
         {
             //This was code to attempt to guess passthroughs for a collision if you are reading this DO NOT USE THIS
+            // //How about this code?
+            Collision c = (Collision)currentEntry;
+            for (int i = 0; i < c.verts.Count - 1; i++)
+            {
+                decimal lineAngle = (decimal)(Math.Atan2(c.verts[i].x-c.verts[i+1].x, c.verts[i].y-c.verts[i+1].y) * 180/Math.PI);
+                double theta = (double)(lineAngle+90);
+                c.normals[i].x = (float)Math.Cos(theta * Math.PI / 180.0f);
+                c.normals[i].y = (float)Math.Sin(theta * Math.PI / 180.0f);
+            }
+            
+            // //Original code
+            /*
             Collision c = (Collision)currentEntry;
             Bounds collisionBounds = new Bounds() { top = -1000000, bottom = 1000000, left = 1000000, right = -1000000 };
             foreach (Vector2D v in c.verts)
@@ -591,6 +603,7 @@ namespace Smash_Forge
                     c.normals[i].x = (float)normal.Y;
                 }
             }
+            */
         }
 
         public void Clear()

--- a/Smash Forge/GUI/Menus/DAEImportSettings.cs
+++ b/Smash Forge/GUI/Menus/DAEImportSettings.cs
@@ -140,7 +140,11 @@ namespace Smash_Forge
                                 v.uv[i] = new Vector2(v.uv[i].X, 1 - v.uv[i].Y);
 
                         if (vertColorDivCB.Checked)
-                            v.col = v.col / 2;
+                            //v.col = v.col / 2;
+                        {
+                            for (int i = 0; i < 3; i++)
+                                v.col[i] = v.col[i] / 2;
+                        }
 
                         if (vertcolorCB.Checked)
                             v.col = new Vector4(0x7F, 0x7F, 0x7F, 0x7F);


### PR DESCRIPTION
I've made some relatively minor changes.

- Render cliffs of LVD collisions in the viewport. Each cliff is now rendered in the viewport, with a white line at its position and a blue line representing its angle.

- Add code for guessing passthrough angles on LVD collisions (unused). There was code present in a button function for the LVD GUI for (an attempt at) guessing the passthrough angles of all lines in a collision. I commented out this code and added some new code (math from jam1garner's old python lvd tool; it seems he wrote most of the lvd code for Forge, too), which seems like it could work. The button this code is attached to was and still is disabled.

- Modify DAE importing option 'Divide vertex color by 2'. The previous code halved all four channels of the color (RGBA), now it only divides the color channels (RGB). Halving of vertex alpha usually wouldn't be wanted when using this option.