### PR TITLE
LVD rendering and NUD tweaks

### DIFF
--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -138,7 +138,7 @@ namespace Smash_Forge
         public override string magic { get { return "030401017735BB7500000002"; } }
         
         public Vector2D pos;
-        public Vector2D angle; //Someone figure out what these angles are
+        public Vector2D angle; //Someone figure out what these angles do
         
         public void read(FileData f)
         {
@@ -858,16 +858,56 @@ namespace Smash_Forge
 
         #region rendering
 
+        public static void DrawPoint(GeneralPoint p)
+        {
+            GL.LineWidth(2);
+            
+            GL.Color4(Color.FromArgb(200, Color.Fuchsia));
+            RenderTools.drawCubeWireframe(new Vector3(p.x, p.y, p.z), 3);
+        }
+        
+        public static void DrawShape(GeneralShape s)
+        {
+            GL.LineWidth(2);
+            GL.Color4(Color.FromArgb(200, Color.Fuchsia));
+
+            if(s.type == 3)
+            {
+                GL.Begin(PrimitiveType.LineLoop);
+                GL.Vertex3(s.x1, s.y1, 0);
+                GL.Vertex3(s.x2, s.y1, 0);
+                GL.Vertex3(s.x2, s.y2, 0);
+                GL.Vertex3(s.x1, s.y2, 0);
+            }
+            if(s.type == 4)
+            {
+                GL.Begin(PrimitiveType.LineStrip);
+                foreach(Vector2D point in s.points)
+                    GL.Vertex3(point.x, point.y, 0);
+            }
+
+            GL.End();
+        }
+
+        public static void DrawShape(DamageShape s)
+        {
+            GL.LineWidth(2);
+            GL.Color4(Color.FromArgb(128, Color.Yellow));
+
+            if (s.type == 2)
+                RenderTools.drawSphere(new Vector3(s.x, s.y, s.z), s.radius, 24);
+            if (s.type == 3)
+                RenderTools.drawCylinder(new Vector3(s.x, s.y, s.z), new Vector3(s.x + s.dx, s.y + s.dy, s.z + s.dz), s.radius);
+        }
+
         public static void DrawSpawn(Spawn s, bool isRespawn)
         {
+            GL.LineWidth(2);
             DrawRespawnQuad(s, Color.Blue);
 
             //Draw respawn platform
             if (isRespawn)
-            {
                 DrawRespawnArrow(s, Color.Gray, Color.Black);
-            }
-
         }
 
         private static void DrawRespawnQuad(Spawn s, Color color)
@@ -941,6 +981,8 @@ namespace Smash_Forge
 
         public static void DrawBounds(Bounds b, Color color)
         {
+            GL.LineWidth(2);
+            
             GL.Color4(Color.FromArgb(128, color));
             GL.Begin(PrimitiveType.LineLoop);
             GL.Vertex3(b.left, b.top, 0);
@@ -950,7 +992,7 @@ namespace Smash_Forge
             GL.End();
         }
 
-        public static void RenderItemSpawners()
+        public static void DrawItemSpawners()
         {
             foreach (ItemSpawner c in Runtime.TargetLVD.items)
             {
@@ -1132,9 +1174,9 @@ namespace Smash_Forge
                     float add2X = 0, add2Y = 0, add2Z = 0;
                     if (c.cliffs[i].useStartPos)
                     {
-                        add2X = c.startPos[0];
-                        add2Y = c.startPos[1];
-                        add2Z = c.startPos[2];
+                        add2X = c.cliffs[i].startPos[0];
+                        add2Y = c.cliffs[i].startPos[1];
+                        add2Z = c.cliffs[i].startPos[2];
                     }
                     
                     Vector3 v1Pos = Vector3.Transform(new Vector3(c.cliffs[i].pos.x + add2X, c.cliffs[i].pos.y + add2Y, add2Z + 10), transform);
@@ -1143,14 +1185,12 @@ namespace Smash_Forge
                     
                     GL.Begin(PrimitiveType.Lines);
                     GL.Color4(Color.White);
-                    
                     GL.Vertex3(v1Pos);
                     GL.Vertex3(v1Neg);
                     GL.End();
                     
                     GL.Begin(PrimitiveType.Lines);
                     GL.Color3(Color.Blue);
-                    
                     GL.Vertex3(v1Zer);
                     GL.Vertex3(v1Zer.X + (c.cliffs[i].angle.x * 10), v1Zer.Y + (c.cliffs[i].angle.y * 10), v1Zer.Z);
                     GL.End();

--- a/Smash Forge/Filetypes/Models/NUD.cs
+++ b/Smash Forge/Filetypes/Models/NUD.cs
@@ -499,17 +499,20 @@ namespace Smash_Forge
 
             // face culling
             GL.Enable(EnableCap.CullFace);
-            GL.CullFace(CullFaceMode.Front);
+            GL.CullFace(CullFaceMode.Back);
             switch (material.cullMode)
             {
-                case 0:
+                case 0x0000:
                     GL.Disable(EnableCap.CullFace);
                     break;
-                case 0x0205:
+                case 0x0404:
                     GL.CullFace(CullFaceMode.Front);
                     break;
                 case 0x0405:
                     GL.CullFace(CullFaceMode.Back);
+                    break;
+                default:
+                    GL.Disable(EnableCap.CullFace);
                     break;
             }
             if (p.Checked)

--- a/Smash Forge/GUI/Editors/NUDMaterialEditor.cs
+++ b/Smash Forge/GUI/Editors/NUDMaterialEditor.cs
@@ -79,7 +79,7 @@ namespace Smash_Forge
 
         public static Dictionary<int, string> cullmode = new Dictionary<int, string>(){
                     { 0x0000, "Cull None"},
-                    { 0x0205, "Cull Front"},
+                    { 0x0404, "Cull Outside"},
                     { 0x0405, "Cull Inside"}
                 };
 

--- a/Smash Forge/GUI/Editors/VBNViewport.cs
+++ b/Smash Forge/GUI/Editors/VBNViewport.cs
@@ -1226,85 +1226,40 @@ namespace Smash_Forge
 
                 if (Runtime.renderItemSpawners)
                 {
-                    LVD.RenderItemSpawners();
+                    LVD.DrawItemSpawners();
                 }
 
                 if (Runtime.renderSpawns)
                 {
                     foreach (Spawn s in Runtime.TargetLVD.spawns)
-                    {
                         LVD.DrawSpawn(s, false);
-                    }
                 }
 
                 if (Runtime.renderRespawns)
                 {
                     foreach (Spawn s in Runtime.TargetLVD.respawns)
-                    {
                         LVD.DrawSpawn(s,true);
-                    }
                 }
 
                 if (Runtime.renderGeneralPoints)
                 {
-                    foreach (GeneralPoint g in Runtime.TargetLVD.generalPoints)
-                    {
-                        GL.Color4(Color.FromArgb(200, Color.Fuchsia));
-                        RenderTools.drawCubeWireframe(new Vector3(g.x, g.y, 0), 3);
-                    }
+                    foreach (GeneralPoint p in Runtime.TargetLVD.generalPoints)
+                        LVD.DrawPoint(p);
                     
-                    foreach (GeneralShape shape in Runtime.TargetLVD.generalShapes)
-                    {
-                        /*if(shape is GeneralPoint)
-                        {
-                            GeneralPoint g = (GeneralPoint)shape;
-                            GL.Color4(Color.FromArgb(200, Color.Fuchsia));
-                            RenderTools.drawCubeWireframe(new Vector3(g.x, g.y, 0), 3);
-                        }*/
-                        if(shape.type == 3)
-                        {
-                            GeneralShape b = (GeneralShape)shape;
-                            GL.Color4(Color.FromArgb(200, Color.Fuchsia));
-                            GL.Begin(PrimitiveType.LineLoop);
-                            GL.Vertex3(b.x1, b.y1, 0);
-                            GL.Vertex3(b.x2, b.y1, 0);
-                            GL.Vertex3(b.x2, b.y2, 0);
-                            GL.Vertex3(b.x1, b.y2, 0);
-                            GL.End();
-                        }
-                        if(shape.type == 4)
-                        {
-                            List<Vector2D> p = ((GeneralShape)shape).points;
-                            GL.Color4(Color.FromArgb(200, Color.Fuchsia));
-                            GL.Begin(PrimitiveType.LineStrip);
-                            foreach(Vector2D point in p)
-                                GL.Vertex3(point.x, point.y, 0);
-                            GL.End();
-                        }
-                    }
+                    foreach (GeneralShape s in Runtime.TargetLVD.generalShapes)
+                        LVD.DrawShape(s);
                 }
 
                 if (Runtime.renderOtherLVDEntries)
                 {
-                    GL.Color4(Color.FromArgb(128, Color.Yellow));
                     foreach (DamageShape s in Runtime.TargetLVD.damageShapes)
-                    {
-                        if (s.type == 2)
-                            RenderTools.drawSphere(new Vector3(s.x, s.y, s.z), s.radius, 24);
-                        if (s.type == 3)
-                            RenderTools.drawCylinder(new Vector3(s.x, s.y, s.z), new Vector3(s.x + s.dx, s.y + s.dy, s.z + s.dz), s.radius);
-                    }
-
-
-                    foreach (Bounds b in Runtime.TargetLVD.blastzones)
-                    {
-                        LVD.DrawBounds(b, Color.Red);
-                    }
+                        LVD.DrawShape(s);
 
                     foreach (Bounds b in Runtime.TargetLVD.cameraBounds)
-                    {
                         LVD.DrawBounds(b, Color.Blue);
-                    }
+
+                    foreach (Bounds b in Runtime.TargetLVD.blastzones)
+                        LVD.DrawBounds(b, Color.Red);
                 }
             }
 

--- a/Smash Forge/GUI/Menus/RenderSettings.Designer.cs
+++ b/Smash Forge/GUI/Menus/RenderSettings.Designer.cs
@@ -846,8 +846,9 @@
             this.checkBox11.Name = "checkBox11";
             this.checkBox11.Size = new System.Drawing.Size(133, 17);
             this.checkBox11.TabIndex = 26;
-            this.checkBox11.Text = "Render General Points";
+            this.checkBox11.Text = "Render General Shapes and Points";
             this.checkBox11.UseVisualStyleBackColor = true;
+            this.checkBox11.CheckedChanged += new System.EventHandler(this.checkChanged);
             // 
             // checkBox1
             // 


### PR DESCRIPTION
- Move rendering of LVD objects to functions. This makes the rendering of LVD objects more accessible. It also fixes a bug in which objects could be rendered differently based on which types of objects are being rendered, due to GL variables that weren't being set consistently.

- Rename render settings checkbox 'Render General Points' to 'Render General Shapes and Points', fix it toggling improperly. The checkbox would previously only toggle the rendering state after another checkbox was toggled, due to a missing event call.

- Update NUD material cull modes. Previously, the value 0x205 was listed as the option for 'Cull Outside' (listed as 'Cull Front'), however this value is just another equivalent to 'Cull None'. I removed it and added the value 0x404 as the option for 'Cull Outside' instead (which is true to the game). I also made the default behavior for non-option cull mode values to function as 'Cull None'.