### PR TITLE
Minor bugfixes

### DIFF
--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -864,6 +864,7 @@ namespace Smash_Forge
 
             Vector3 pos = p.useStartPos ? p.startPos : new Vector3(p.x,p.y,p.z);
 
+            GL.Color3(Color.Red);
             RenderTools.drawCubeWireframe(pos, 3);
         }
 

--- a/Smash Forge/Filetypes/Models/NUD.cs
+++ b/Smash Forge/Filetypes/Models/NUD.cs
@@ -226,8 +226,10 @@ namespace Smash_Forge
         private void DrawBoundingBoxes()
         {
             GL.UseProgram(0);
+
             GL.Color4(Color.GhostWhite);
             RenderTools.drawCubeWireframe(new Vector3(boundingBox[0], boundingBox[1], boundingBox[2]), boundingBox[3]);
+
             GL.Color4(Color.OrangeRed);
             foreach (NUD.Mesh mesh in meshes)
             {

--- a/Smash Forge/GUI/Editors/NUDMaterialEditor.cs
+++ b/Smash Forge/GUI/Editors/NUDMaterialEditor.cs
@@ -1057,7 +1057,7 @@ namespace Smash_Forge
         {
             if ((e.KeyChar == 'd') && propertiesListView.SelectedIndices.Count > 0)
             {
-                if (materials[current].textures.Count > 1)
+                if (materials[current].entries.Count > 1)
                 {
                     materials[current].entries.Remove(propertiesListView.SelectedItems[0].Text);
                     FillForm();

--- a/Smash Forge/GUI/Editors/VBNViewport.cs
+++ b/Smash Forge/GUI/Editors/VBNViewport.cs
@@ -1143,7 +1143,10 @@ namespace Smash_Forge
             {
                 if (m.nud != null)
                 {
+                    GL.Color4(Color.GhostWhite);
                     RenderTools.drawCubeWireframe(new Vector3(m.nud.boundingBox[0], m.nud.boundingBox[1], m.nud.boundingBox[2]), m.nud.boundingBox[3]);
+
+                    GL.Color4(Color.OrangeRed);
                     foreach (NUD.Mesh mesh in m.nud.meshes)
                     {
                         if (mesh.Checked)

--- a/Smash Forge/Rendering/RenderTools.cs
+++ b/Smash Forge/Rendering/RenderTools.cs
@@ -1199,12 +1199,13 @@ namespace Smash_Forge
 
         public static void drawCubeWireframe(Vector3 center, float size)
         {
-            GL.Color3(Color.Red);
+            //GL.Color3(Color.Red);
             GL.Begin(PrimitiveType.LineLoop);
             GL.Vertex3(center.X + size, center.Y + size, center.Z - size);
             GL.Vertex3(center.X - size, center.Y + size, center.Z - size);
             GL.Vertex3(center.X - size, center.Y + size, center.Z + size);
             GL.Vertex3(center.X + size, center.Y + size, center.Z + size);
+            GL.End();
 
             GL.Begin(PrimitiveType.LineLoop);
             GL.Vertex3(center.X + size, center.Y - size, center.Z + size);


### PR DESCRIPTION
- Fix NUD material property deletion being non-functional. A mistake (caused by a copy-paste) made it so that this feature would only function if the material's amount of textures greater than one, as opposed to its amount of properties.

- Remove defining of GL color from render function 'drawCubeWireframe'. This function contained a statement to set the color to red, which would override attempts to set the color by code using the function, thus making the resulting cube always red. Now the color can be set without being overriden, which has enabled NUD bounding boxes to render with the colors they were intended to.