### PR TITLE
LVD UI rework Part 2

### DIFF
--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -1227,8 +1227,9 @@ namespace Smash_Forge
                 sPos = new Vector3(0, 0, 0);
                 s = (LVDShape)obj;
             }
-            else if (obj is GeneralShape g)
+            else if (obj is GeneralShape)
             {
+                GeneralShape g = (GeneralShape)obj;
                 useStartPos = g.useStartPos;
                 if (useStartPos)
                     sPos = g.startPos;

--- a/Smash Forge/Filetypes/Melee/DAT.cs
+++ b/Smash Forge/Filetypes/Melee/DAT.cs
@@ -568,7 +568,7 @@ namespace Smash_Forge
                 currentMat.setFlag(6, true);
                 currentMat.setFlag(7, true);
             }
-            currentMat.setPhysics(link.material);
+            currentMat.physics = link.material;
             c.materials.Add(currentMat);
         }
 

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.Designer.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.Designer.cs
@@ -71,12 +71,12 @@
             this.pointShapeZ = new System.Windows.Forms.NumericUpDown();
             this.pointShapeY = new System.Windows.Forms.NumericUpDown();
             this.pointShapeX = new System.Windows.Forms.NumericUpDown();
-            this.pointGroup = new System.Windows.Forms.GroupBox();
+            this.point2dGroup = new System.Windows.Forms.GroupBox();
             this.label12 = new System.Windows.Forms.Label();
             this.label11 = new System.Windows.Forms.Label();
             this.yPoint = new System.Windows.Forms.NumericUpDown();
             this.xPoint = new System.Windows.Forms.NumericUpDown();
-            this.boundGroup = new System.Windows.Forms.GroupBox();
+            this.boundsGroup = new System.Windows.Forms.GroupBox();
             this.label15 = new System.Windows.Forms.Label();
             this.label16 = new System.Windows.Forms.Label();
             this.bottomVal = new System.Windows.Forms.NumericUpDown();
@@ -179,10 +179,10 @@
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeZ)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeY)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeX)).BeginInit();
-            this.pointGroup.SuspendLayout();
+            this.point2dGroup.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.yPoint)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.xPoint)).BeginInit();
-            this.boundGroup.SuspendLayout();
+            this.boundsGroup.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.bottomVal)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.leftVal)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.topVal)).BeginInit();
@@ -222,19 +222,21 @@
             this.flowLayoutPanel1.Controls.Add(this.lvdEntryGroup);
             this.flowLayoutPanel1.Controls.Add(this.collisionGroup);
             this.flowLayoutPanel1.Controls.Add(this.point3dGroup);
-            this.flowLayoutPanel1.Controls.Add(this.pointGroup);
-            this.flowLayoutPanel1.Controls.Add(this.boundGroup);
+            this.flowLayoutPanel1.Controls.Add(this.point2dGroup);
+            this.flowLayoutPanel1.Controls.Add(this.boundsGroup);
             this.flowLayoutPanel1.Controls.Add(this.itemSpawnerGroup);
             this.flowLayoutPanel1.Controls.Add(this.rectangleGroup);
             this.flowLayoutPanel1.Controls.Add(this.pathGroup);
             this.flowLayoutPanel1.Controls.Add(this.meleeCollisionGroup);
             this.flowLayoutPanel1.Controls.Add(this.groupBox1);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.WrapContents = false;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(651, 652);
+            this.flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(0);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(280, 900);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // lvdEntryGroup
@@ -255,7 +257,7 @@
             this.lvdEntryGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.lvdEntryGroup.Name = "lvdEntryGroup";
             this.lvdEntryGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.lvdEntryGroup.Size = new System.Drawing.Size(240, 200);
+            this.lvdEntryGroup.Size = new System.Drawing.Size(276, 200);
             this.lvdEntryGroup.TabIndex = 0;
             this.lvdEntryGroup.TabStop = false;
             this.lvdEntryGroup.Text = "LVD Object";
@@ -436,11 +438,11 @@
             this.collisionGroup.Controls.Add(this.button2);
             this.collisionGroup.Controls.Add(this.button1);
             this.collisionGroup.Controls.Add(this.label1);
-            this.collisionGroup.Location = new System.Drawing.Point(2, 220);
+            this.collisionGroup.Location = new System.Drawing.Point(2, 206);
             this.collisionGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.collisionGroup.Name = "collisionGroup";
             this.collisionGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.collisionGroup.Size = new System.Drawing.Size(240, 450);
+            this.collisionGroup.Size = new System.Drawing.Size(276, 442);
             this.collisionGroup.TabIndex = 0;
             this.collisionGroup.TabStop = false;
             this.collisionGroup.Text = "Collision Editing";
@@ -737,7 +739,7 @@
             this.point3dGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.point3dGroup.Name = "point3dGroup";
             this.point3dGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.point3dGroup.Size = new System.Drawing.Size(240, 46);
+            this.point3dGroup.Size = new System.Drawing.Size(276, 46);
             this.point3dGroup.TabIndex = 34;
             this.point3dGroup.TabStop = false;
             this.point3dGroup.Text = "3D Point";
@@ -833,20 +835,20 @@
             this.pointShapeX.TabIndex = 32;
             this.pointShapeX.ValueChanged += new System.EventHandler(this.pointShape_ValueChanged);
             // 
-            // pointGroup
+            // point2dGroup
             // 
-            this.pointGroup.Controls.Add(this.label12);
-            this.pointGroup.Controls.Add(this.label11);
-            this.pointGroup.Controls.Add(this.yPoint);
-            this.pointGroup.Controls.Add(this.xPoint);
-            this.pointGroup.Location = new System.Drawing.Point(2, 600);
-            this.pointGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.pointGroup.Name = "pointGroup";
-            this.pointGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.pointGroup.Size = new System.Drawing.Size(240, 46);
-            this.pointGroup.TabIndex = 3;
-            this.pointGroup.TabStop = false;
-            this.pointGroup.Text = "2D Point";
+            this.point2dGroup.Controls.Add(this.label12);
+            this.point2dGroup.Controls.Add(this.label11);
+            this.point2dGroup.Controls.Add(this.yPoint);
+            this.point2dGroup.Controls.Add(this.xPoint);
+            this.point2dGroup.Location = new System.Drawing.Point(2, 600);
+            this.point2dGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.point2dGroup.Name = "point2dGroup";
+            this.point2dGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.point2dGroup.Size = new System.Drawing.Size(276, 46);
+            this.point2dGroup.TabIndex = 3;
+            this.point2dGroup.TabStop = false;
+            this.point2dGroup.Text = "2D Point";
             // 
             // label12
             // 
@@ -908,24 +910,24 @@
             this.xPoint.TabIndex = 32;
             this.xPoint.ValueChanged += new System.EventHandler(this.pointMoved);
             // 
-            // boundGroup
+            // boundsGroup
             // 
-            this.boundGroup.Controls.Add(this.label15);
-            this.boundGroup.Controls.Add(this.label16);
-            this.boundGroup.Controls.Add(this.bottomVal);
-            this.boundGroup.Controls.Add(this.leftVal);
-            this.boundGroup.Controls.Add(this.label13);
-            this.boundGroup.Controls.Add(this.label14);
-            this.boundGroup.Controls.Add(this.topVal);
-            this.boundGroup.Controls.Add(this.rightVal);
-            this.boundGroup.Location = new System.Drawing.Point(215, 2);
-            this.boundGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.boundGroup.Name = "boundGroup";
-            this.boundGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.boundGroup.Size = new System.Drawing.Size(240, 67);
-            this.boundGroup.TabIndex = 34;
-            this.boundGroup.TabStop = false;
-            this.boundGroup.Text = "Bounds";
+            this.boundsGroup.Controls.Add(this.label15);
+            this.boundsGroup.Controls.Add(this.label16);
+            this.boundsGroup.Controls.Add(this.bottomVal);
+            this.boundsGroup.Controls.Add(this.leftVal);
+            this.boundsGroup.Controls.Add(this.label13);
+            this.boundsGroup.Controls.Add(this.label14);
+            this.boundsGroup.Controls.Add(this.topVal);
+            this.boundsGroup.Controls.Add(this.rightVal);
+            this.boundsGroup.Location = new System.Drawing.Point(215, 2);
+            this.boundsGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.boundsGroup.Name = "boundsGroup";
+            this.boundsGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.boundsGroup.Size = new System.Drawing.Size(276, 67);
+            this.boundsGroup.TabIndex = 34;
+            this.boundsGroup.TabStop = false;
+            this.boundsGroup.Text = "Bounds";
             // 
             // label15
             // 
@@ -1065,7 +1067,7 @@
             this.itemSpawnerGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.itemSpawnerGroup.Name = "itemSpawnerGroup";
             this.itemSpawnerGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.itemSpawnerGroup.Size = new System.Drawing.Size(188, 300);
+            this.itemSpawnerGroup.Size = new System.Drawing.Size(276, 300);
             this.itemSpawnerGroup.TabIndex = 35;
             this.itemSpawnerGroup.TabStop = false;
             this.itemSpawnerGroup.Text = "Item Spawner";
@@ -1229,7 +1231,7 @@
             this.rectangleGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.rectangleGroup.Name = "rectangleGroup";
             this.rectangleGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.rectangleGroup.Size = new System.Drawing.Size(240, 67);
+            this.rectangleGroup.Size = new System.Drawing.Size(276, 67);
             this.rectangleGroup.TabIndex = 38;
             this.rectangleGroup.TabStop = false;
             this.rectangleGroup.Text = "Rectangle (Shape)";
@@ -1371,7 +1373,7 @@
             this.pathGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.pathGroup.Name = "pathGroup";
             this.pathGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-            this.pathGroup.Size = new System.Drawing.Size(188, 166);
+            this.pathGroup.Size = new System.Drawing.Size(276, 166);
             this.pathGroup.TabIndex = 46;
             this.pathGroup.TabStop = false;
             this.pathGroup.Text = "General Path (Shape)";
@@ -2171,7 +2173,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(651, 652);
+            this.ClientSize = new System.Drawing.Size(280, 900);
             this.Controls.Add(this.flowLayoutPanel1);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
@@ -2196,12 +2198,12 @@
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeZ)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeY)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeX)).EndInit();
-            this.pointGroup.ResumeLayout(false);
-            this.pointGroup.PerformLayout();
+            this.point2dGroup.ResumeLayout(false);
+            this.point2dGroup.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.yPoint)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.xPoint)).EndInit();
-            this.boundGroup.ResumeLayout(false);
-            this.boundGroup.PerformLayout();
+            this.boundsGroup.ResumeLayout(false);
+            this.boundsGroup.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.bottomVal)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.leftVal)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.topVal)).EndInit();
@@ -2281,12 +2283,12 @@
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.NumericUpDown yVert;
         private System.Windows.Forms.NumericUpDown xVert;
-        private System.Windows.Forms.GroupBox pointGroup;
+        private System.Windows.Forms.GroupBox point2dGroup;
         private System.Windows.Forms.NumericUpDown yPoint;
         private System.Windows.Forms.NumericUpDown xPoint;
         private System.Windows.Forms.Label label12;
         private System.Windows.Forms.Label label11;
-        private System.Windows.Forms.GroupBox boundGroup;
+        private System.Windows.Forms.GroupBox boundsGroup;
         private System.Windows.Forms.Label label13;
         private System.Windows.Forms.Label label14;
         private System.Windows.Forms.NumericUpDown topVal;

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.Designer.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.Designer.cs
@@ -64,6 +64,15 @@
             this.button2 = new System.Windows.Forms.Button();
             this.button1 = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
+            this.cliffGroup = new System.Windows.Forms.GroupBox();
+            this.label52 = new System.Windows.Forms.Label();
+            this.label51 = new System.Windows.Forms.Label();
+            this.label50 = new System.Windows.Forms.Label();
+            this.label49 = new System.Windows.Forms.Label();
+            this.cliffLineIndex = new System.Windows.Forms.NumericUpDown();
+            this.cliffAngle = new System.Windows.Forms.NumericUpDown();
+            this.cliffPosY = new System.Windows.Forms.NumericUpDown();
+            this.cliffPosX = new System.Windows.Forms.NumericUpDown();
             this.point3dGroup = new System.Windows.Forms.GroupBox();
             this.label48 = new System.Windows.Forms.Label();
             this.label22 = new System.Windows.Forms.Label();
@@ -175,6 +184,11 @@
             ((System.ComponentModel.ISupportInitialize)(this.yVert)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.xVert)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.passthroughAngle)).BeginInit();
+            this.cliffGroup.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.cliffLineIndex)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cliffAngle)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cliffPosY)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cliffPosX)).BeginInit();
             this.point3dGroup.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeZ)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeY)).BeginInit();
@@ -221,6 +235,7 @@
             // 
             this.flowLayoutPanel1.Controls.Add(this.lvdEntryGroup);
             this.flowLayoutPanel1.Controls.Add(this.collisionGroup);
+            this.flowLayoutPanel1.Controls.Add(this.cliffGroup);
             this.flowLayoutPanel1.Controls.Add(this.point3dGroup);
             this.flowLayoutPanel1.Controls.Add(this.point2dGroup);
             this.flowLayoutPanel1.Controls.Add(this.boundsGroup);
@@ -726,6 +741,138 @@
             this.label1.Size = new System.Drawing.Size(45, 13);
             this.label1.TabIndex = 1;
             this.label1.Text = "Vertices";
+            // 
+            // cliffGroup
+            // 
+            this.cliffGroup.Controls.Add(this.label52);
+            this.cliffGroup.Controls.Add(this.label51);
+            this.cliffGroup.Controls.Add(this.label50);
+            this.cliffGroup.Controls.Add(this.label49);
+            this.cliffGroup.Controls.Add(this.cliffLineIndex);
+            this.cliffGroup.Controls.Add(this.cliffAngle);
+            this.cliffGroup.Controls.Add(this.cliffPosY);
+            this.cliffGroup.Controls.Add(this.cliffPosX);
+            this.cliffGroup.Location = new System.Drawing.Point(2, 550);
+            this.cliffGroup.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.cliffGroup.Name = "cliffGroup";
+            this.cliffGroup.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.cliffGroup.Size = new System.Drawing.Size(276, 97);
+            this.cliffGroup.TabIndex = 34;
+            this.cliffGroup.TabStop = false;
+            this.cliffGroup.Text = "Collision Cliff";
+            this.cliffGroup.Visible = false;
+            // 
+            // label52
+            // 
+            this.label52.AutoSize = true;
+            this.label52.Location = new System.Drawing.Point(6, 75);
+            this.label52.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label52.Name = "label52";
+            this.label52.Size = new System.Drawing.Size(14, 13);
+            this.label52.TabIndex = 32;
+            this.label52.Text = "Line";
+            // 
+            // label51
+            // 
+            this.label51.AutoSize = true;
+            this.label51.Location = new System.Drawing.Point(6, 50);
+            this.label51.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label51.Name = "label51";
+            this.label51.Size = new System.Drawing.Size(14, 13);
+            this.label51.TabIndex = 32;
+            this.label51.Text = "Angle";
+            // 
+            // label50
+            // 
+            this.label50.AutoSize = true;
+            this.label50.Location = new System.Drawing.Point(84, 20);
+            this.label50.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label50.Name = "label50";
+            this.label50.Size = new System.Drawing.Size(14, 13);
+            this.label50.TabIndex = 32;
+            this.label50.Text = "Y";
+            // 
+            // label49
+            // 
+            this.label49.AutoSize = true;
+            this.label49.Location = new System.Drawing.Point(6, 20);
+            this.label49.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label49.Name = "label49";
+            this.label49.Size = new System.Drawing.Size(14, 13);
+            this.label49.TabIndex = 32;
+            this.label49.Text = "X";
+            // 
+            // cliffLineIndex
+            // 
+            this.cliffLineIndex.DecimalPlaces = 0;
+            this.cliffLineIndex.Location = new System.Drawing.Point(40, 73);
+            this.cliffLineIndex.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.cliffLineIndex.Maximum = 1;
+            this.cliffLineIndex.Minimum = 1;
+            this.cliffLineIndex.Name = "cliffLineIndex";
+            this.cliffLineIndex.Size = new System.Drawing.Size(36, 20);
+            this.cliffLineIndex.TabIndex = 34;
+            this.cliffLineIndex.ValueChanged += new System.EventHandler(this.cliff_ValueChanged);
+            // 
+            // cliffAngle
+            // 
+            this.cliffAngle.DecimalPlaces = 4;
+            this.cliffAngle.Location = new System.Drawing.Point(40, 48);
+            this.cliffAngle.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.cliffAngle.Maximum = new decimal(new int[] {
+            1000000000,
+            0,
+            0,
+            0});
+            this.cliffAngle.Minimum = new decimal(new int[] {
+            1000000000,
+            0,
+            0,
+            -2147483648});
+            this.cliffAngle.Name = "cliffAngle";
+            this.cliffAngle.Size = new System.Drawing.Size(56, 20);
+            this.cliffAngle.TabIndex = 34;
+            this.cliffAngle.ValueChanged += new System.EventHandler(this.cliff_ValueChanged);
+            // 
+            // cliffPosY
+            // 
+            this.cliffPosY.DecimalPlaces = 4;
+            this.cliffPosY.Location = new System.Drawing.Point(100, 18);
+            this.cliffPosY.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.cliffPosY.Maximum = new decimal(new int[] {
+            1000000000,
+            0,
+            0,
+            0});
+            this.cliffPosY.Minimum = new decimal(new int[] {
+            1000000000,
+            0,
+            0,
+            -2147483648});
+            this.cliffPosY.Name = "cliffPosY";
+            this.cliffPosY.Size = new System.Drawing.Size(56, 20);
+            this.cliffPosY.TabIndex = 33;
+            this.cliffPosY.ValueChanged += new System.EventHandler(this.cliff_ValueChanged);
+            // 
+            // cliffPosX
+            // 
+            this.cliffPosX.DecimalPlaces = 4;
+            this.cliffPosX.Location = new System.Drawing.Point(22, 18);
+            this.cliffPosX.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.cliffPosX.Maximum = new decimal(new int[] {
+            1000000000,
+            0,
+            0,
+            0});
+            this.cliffPosX.Minimum = new decimal(new int[] {
+            1000000000,
+            0,
+            0,
+            -2147483648});
+            this.cliffPosX.Name = "cliffPosX";
+            this.cliffPosX.Size = new System.Drawing.Size(56, 20);
+            this.cliffPosX.TabIndex = 32;
+            this.cliffPosX.ValueChanged += new System.EventHandler(this.cliff_ValueChanged);
             // 
             // point3dGroup
             // 
@@ -2193,6 +2340,12 @@
             ((System.ComponentModel.ISupportInitialize)(this.yVert)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.xVert)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.passthroughAngle)).EndInit();
+            this.cliffGroup.ResumeLayout(false);
+            this.cliffGroup.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.cliffLineIndex)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cliffAngle)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cliffPosY)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.cliffPosX)).EndInit();
             this.point3dGroup.ResumeLayout(false);
             this.point3dGroup.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pointShapeZ)).EndInit();
@@ -2312,6 +2465,15 @@
         private System.Windows.Forms.Label label18;
         private System.Windows.Forms.Button button4;
         private System.Windows.Forms.Label label19;
+        private System.Windows.Forms.GroupBox cliffGroup;
+        private System.Windows.Forms.Label label52;
+        private System.Windows.Forms.Label label51;
+        private System.Windows.Forms.Label label50;
+        private System.Windows.Forms.Label label49;
+        private System.Windows.Forms.NumericUpDown cliffLineIndex;
+        private System.Windows.Forms.NumericUpDown cliffAngle;
+        private System.Windows.Forms.NumericUpDown cliffPosY;
+        private System.Windows.Forms.NumericUpDown cliffPosX;
         private System.Windows.Forms.GroupBox point3dGroup;
         private System.Windows.Forms.Label label48;
         private System.Windows.Forms.Label label22;

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
@@ -72,8 +72,8 @@ namespace Smash_Forge
         {
             lvdEntryGroup.Visible = false;
             collisionGroup.Visible = false;
-            pointGroup.Visible = false;
-            boundGroup.Visible = false;
+            point2dGroup.Visible = false;
+            boundsGroup.Visible = false;
             itemSpawnerGroup.Visible = false;
             point3dGroup.Visible = false;
             rectangleGroup.Visible = false;
@@ -117,14 +117,14 @@ namespace Smash_Forge
                 }
                 else if (entry is Spawn)
                 {
-                    pointGroup.Visible = true;
+                    point2dGroup.Visible = true;
                     currentPoint = (Spawn)entry;
                     xPoint.Value = (decimal)((Spawn)entry).x;
                     yPoint.Value = (decimal)((Spawn)entry).y;
                 }
                 else if (entry is Bounds)
                 {
-                    boundGroup.Visible = true;
+                    boundsGroup.Visible = true;
                     currentBounds = (Bounds)entry;
                     topVal.Value = (decimal)currentBounds.top;
                     rightVal.Value = (decimal)currentBounds.right;
@@ -155,7 +155,7 @@ namespace Smash_Forge
                     GeneralShape s = (GeneralShape)entry;
                     if (s.type == 1)
                     {
-                        pointGroup.Visible = true;
+                        point2dGroup.Visible = true;
                         xPoint.Value = (decimal)s.x1;
                         yPoint.Value = (decimal)s.y1;
                     }
@@ -300,8 +300,8 @@ namespace Smash_Forge
         {
             lvdEntryGroup.Visible = false;
             collisionGroup.Visible = false;
-            pointGroup.Visible = false;
-            boundGroup.Visible = false;
+            point2dGroup.Visible = false;
+            boundsGroup.Visible = false;
         }
 
         private void pointMoved(object sender, EventArgs e)
@@ -642,8 +642,8 @@ namespace Smash_Forge
             subname.Text = "";
             lvdEntryGroup.Visible = false;
             collisionGroup.Visible = false;
-            pointGroup.Visible = false;
-            boundGroup.Visible = false;
+            point2dGroup.Visible = false;
+            boundsGroup.Visible = false;
             itemSpawnerGroup.Visible = false;
             point3dGroup.Visible = false;
             rectangleGroup.Visible = false;

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
@@ -191,15 +191,14 @@ namespace Smash_Forge
 
             if(TargetLVD != null)
             {
-                int i = 0;
                 foreach (Collision c in TargetLVD.collisions)
                 {
-                    collisionNode.Nodes.Add(new TreeNode(c.name) { Tag = c, ContextMenu = ElementCM });
+                    TreeNode newNode = new TreeNode(c.name) { Tag = c, ContextMenu = ElementCM };
                     foreach (CollisionCliff d in c.cliffs)
                     {
-                        collisionNode.Nodes[i].Nodes.Add(new TreeNode(d.name) { Tag = d, ContextMenu = ElementCM });
+                        newNode.Nodes.Add(new TreeNode(d.name) { Tag = d, ContextMenu = ElementCM });
                     }
-                    i++;
+                    collisionNode.Nodes.Add(newNode);
                 }
 
                 foreach (Spawn c in TargetLVD.spawns)

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
@@ -48,7 +48,7 @@ namespace Smash_Forge
                 {
                     foreach (Collision c in TargetLVD.collisions)
                     {
-                        TargetLVD.GenerateCliffs(c);
+                        LVD.GenerateCliffs(c);
                     }
                     fillList();
                 };
@@ -115,18 +115,6 @@ namespace Smash_Forge
             }
             //---------------------------------------------
             {
-                TreeNode node = pointNode;
-                node.ContextMenu = new ContextMenu();
-                MenuItem Add = new MenuItem("Add New General Point");
-                Add.Click += delegate
-                {
-                    TargetLVD.generalPoints.Add(new GeneralPoint() { name = "GeneralPoint3D_NEW", subname = "00_NEW" });
-                    fillList();
-                };
-                node.ContextMenu.MenuItems.Add(Add);
-            }
-            //---------------------------------------------
-            {
                 TreeNode node = shapeNode;
                 node.ContextMenu = new ContextMenu();
 
@@ -153,6 +141,51 @@ namespace Smash_Forge
                     fillList();
                 };
                 node.ContextMenu.MenuItems.Add(AddPath);
+            }
+            //---------------------------------------------
+            {
+                TreeNode node = pointNode;
+                node.ContextMenu = new ContextMenu();
+                MenuItem Add = new MenuItem("Add New General Point");
+                Add.Click += delegate
+                {
+                    TargetLVD.generalPoints.Add(new GeneralPoint() { name = "GeneralPoint3D_NEW", subname = "00_NEW" });
+                    fillList();
+                };
+                node.ContextMenu.MenuItems.Add(Add);
+            }
+            //---------------------------------------------
+            {
+                TreeNode node = hurtNode;
+                node.ContextMenu = new ContextMenu();
+
+                MenuItem AddSphere = new MenuItem("Add New Damage Sphere");
+                AddSphere.Click += delegate
+                {
+                    TargetLVD.damageShapes.Add(new DamageShape() { name = "DamageeSphere_00_NEW", subname = "00_NEW", type = 2 });
+                    fillList();
+                };
+                node.ContextMenu.MenuItems.Add(AddSphere);
+
+                MenuItem AddCapsule = new MenuItem("Add New Damage Capsule");
+                AddCapsule.Click += delegate
+                {
+                    TargetLVD.damageShapes.Add(new DamageShape() { name = "DamageeCapsule_00_NEW", subname = "00_NEW", type = 3 });
+                    fillList();
+                };
+                node.ContextMenu.MenuItems.Add(AddCapsule);
+            }
+            //---------------------------------------------
+            {
+                TreeNode node = enemyNode;
+                node.ContextMenu = new ContextMenu();
+                MenuItem Add = new MenuItem("Add New Enemy Spawner");
+                Add.Click += delegate
+                {
+                    TargetLVD.enemySpawns.Add(new EnemyGenerator() { name = "EnemyGenerator_NEW", subname = "00_NEW" });
+                    fillList();
+                };
+                node.ContextMenu.MenuItems.Add(Add);
             }
 
             ElementCM = new ContextMenu();
@@ -258,38 +291,46 @@ namespace Smash_Forge
             }
         }
 
+        public void deleteNode(TreeNode treeNode)
+        {
+            if (!(treeNode.Tag is LVDEntry))
+                return;
+            LVDEntry entry = (LVDEntry)treeNode.Tag;
+
+            if (entry is Collision)
+                TargetLVD.collisions.Remove((Collision)entry);
+            if (entry is CollisionCliff)
+                TargetLVD.collisions[treeView1.SelectedNode.Parent.Index].cliffs.Remove((CollisionCliff)entry);
+            if (entry is Spawn)
+            {
+                TargetLVD.respawns.Remove((Spawn)entry);
+                TargetLVD.spawns.Remove((Spawn)entry);
+            }
+            if (entry is Bounds)
+            {
+                TargetLVD.blastzones.Remove((Bounds)entry);
+                TargetLVD.cameraBounds.Remove((Bounds)entry);
+            }
+            if (entry is DamageShape)
+                TargetLVD.damageShapes.Remove((DamageShape)entry);
+            if (entry is EnemyGenerator)
+                TargetLVD.enemySpawns.Remove((EnemyGenerator)entry);
+            if (entry is GeneralShape)
+                TargetLVD.generalShapes.Remove((GeneralShape)entry);
+            if (entry is ItemSpawner)
+                TargetLVD.itemSpawns.Remove((ItemSpawner)entry);
+            if (entry is GeneralPoint)
+                TargetLVD.generalPoints.Remove((GeneralPoint)entry);
+
+            treeView1.Nodes.Remove(treeNode);
+        }
+
         public void deleteSelected()
         {
-            if(treeView1.SelectedNode.Tag is LVDEntry)
-            {
-                LVDEntry entry = (LVDEntry)treeView1.SelectedNode.Tag;
-                if (entry is Bounds)
-                {
-                    TargetLVD.blastzones.Remove((Bounds)entry);
-                    TargetLVD.cameraBounds.Remove((Bounds)entry);
-                }
-                if (entry is Spawn)
-                {
-                    TargetLVD.respawns.Remove((Spawn)entry);
-                    TargetLVD.spawns.Remove((Spawn)entry);
-                }
-                if (entry is Collision)
-                    TargetLVD.collisions.Remove((Collision)entry);
-                if (entry is CollisionCliff)
-                    TargetLVD.collisions[treeView1.SelectedNode.Parent.Index].cliffs.Remove((CollisionCliff)entry);
-                if (entry is DamageShape)
-                    TargetLVD.damageShapes.Remove((DamageShape)entry);
-                if (entry is EnemyGenerator)
-                    TargetLVD.enemySpawns.Remove((EnemyGenerator)entry);
-                if (entry is GeneralShape)
-                    TargetLVD.generalShapes.Remove((GeneralShape)entry);
-                if (entry is ItemSpawner)
-                    TargetLVD.itemSpawns.Remove((ItemSpawner)entry);
-                if (entry is GeneralPoint)
-                    TargetLVD.generalPoints.Remove((GeneralPoint)entry);
+            if (treeView1.SelectedNode == null || !(treeView1.SelectedNode.Tag is LVDEntry))
+                return;
 
-                treeView1.Nodes.Remove(treeView1.SelectedNode);
-            }
+            deleteNode(treeView1.SelectedNode);
         }
 
         private void treeView1_KeyPress(object sender, KeyPressEventArgs e)

--- a/Smash Forge/GUI/Editors/VBNViewport.cs
+++ b/Smash Forge/GUI/Editors/VBNViewport.cs
@@ -1106,10 +1106,11 @@ namespace Smash_Forge
 
                 if (Runtime.renderOtherLVDEntries)
                 {
-                    Runtime.TargetLVD.DrawEnemySpawners();
+                    foreach (EnemyGenerator e in Runtime.TargetLVD.enemySpawns)
+                        LVD.DrawEnemyGenerator(e);
 
                     foreach (DamageShape s in Runtime.TargetLVD.damageShapes)
-                        LVD.DrawShape(s);
+                        LVD.DrawDamageShape(s);
 
                     foreach (Bounds b in Runtime.TargetLVD.cameraBounds)
                         LVD.DrawBounds(b, Color.Blue);

--- a/Smash Forge/Smash Forge.csproj
+++ b/Smash Forge/Smash Forge.csproj
@@ -777,6 +777,9 @@
     <None Include="param_labels\fighter_param_vl_mario.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="param_labels\fighter_param_vl_pikachu.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="param_labels\fighter_param_vl_xxx.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -880,6 +883,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="param_labels\ui_button_sequence.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="param_labels\ui_challenger_battle_db_cafe.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="param_labels\ui_character_db.ini">


### PR DESCRIPTION
Continued work on LVD:
- Cliffs are now fully editable in the GUI.
- Cliff generation now accounts for start position and bone name of parent collisions.
- New 'LVDShape' class replaces previous shape classes, 'Section' class, and 'EnmSection' class entirely. I realized that all of these things are using the same structure for their data.
- ItemSpawner now sets its ID on initialization (to the one most commonly used).
- Add properties to CollisionMaterial class, to allow easier access to collision flags.
- Update shape rendering. GeneralShapes are still rendered in pink, but EnemyGenerators now render their shapes in white and orange (and as the correct shapes, too).
- Cleanup code for adding and removing vertices on a collision. It is less/not prone to exceptions now.
- DamageShapes and EnemyGenerators now have options to be added in the tree-view context menus. I have not yet implemented GUI for these objects, so these options are largely useless at present.
- Cleanup code for deleting nodes from the LVD tree-view.

I may end up doing more on LVD UI, as there is still much to be done, like implementing UI for the object types that do not have it, changing the item spawner UI to reflect the new change to shapes, and adding 'ID' fields to several existing UI groups. I find that UI work can be rather tedious, though.