### PR TITLE
Add LVD passthrough angle calculation (experimental)

### DIFF
--- a/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.cs
@@ -604,12 +604,13 @@ namespace Smash_Forge
             Collision c = (Collision)currentEntry;
             for (int i = 0; i < c.verts.Count - 1; i++)
             {
-                decimal lineAngle = (decimal)(Math.Atan2(c.verts[i].x-c.verts[i+1].x, c.verts[i].y-c.verts[i+1].y) * 180/Math.PI);
-                double theta = (double)(lineAngle+90);
+                decimal currentAngle = (decimal)(Math.Atan2(c.normals[i].y, c.normals[i].x) * 180.0 / Math.PI);
+                decimal newAngle = (decimal)(Math.Atan2(c.verts[i].x-c.verts[i+1].x, c.verts[i].y-c.verts[i+1].y) * 180/Math.PI);
+                double theta = (double)(newAngle);
                 c.normals[i].x = (float)Math.Cos(theta * Math.PI / 180.0f);
                 c.normals[i].y = (float)Math.Sin(theta * Math.PI / 180.0f);
             }
-            
+
             // //Original code
             /*
             Collision c = (Collision)currentEntry;

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
@@ -43,6 +43,16 @@ namespace Smash_Forge
                 };
                 collisionNode.ContextMenu.MenuItems.Add(AddCollision);
 
+                MenuItem GenPassthru = new MenuItem("Regenerate Passthrough Angles");
+                GenPassthru.Click += delegate
+                {
+                    foreach (Collision c in TargetLVD.collisions)
+                    {
+                        LVD.GeneratePassthroughs(c);
+                    }
+                };
+                collisionNode.ContextMenu.MenuItems.Add(GenPassthru);
+
                 MenuItem GenCliffs = new MenuItem("Regenerate Cliffs");
                 GenCliffs.Click += delegate
                 {

--- a/Smash Forge/GUI/Menus/RenderSettings.Designer.cs
+++ b/Smash Forge/GUI/Menus/RenderSettings.Designer.cs
@@ -931,7 +931,7 @@
             this.swagYCB.Name = "swagYCB";
             this.swagYCB.Size = new System.Drawing.Size(104, 17);
             this.swagYCB.TabIndex = 29;
-            this.swagYCB.Text = "Animate Swag Y";
+            this.swagYCB.Text = "Animate Swing Y";
             this.swagYCB.UseVisualStyleBackColor = true;
             this.swagYCB.CheckedChanged += new System.EventHandler(this.swagYCB_CheckedChanged);
             // 
@@ -1065,7 +1065,7 @@
             this.showSwagDataCB.Name = "showSwagDataCB";
             this.showSwagDataCB.Size = new System.Drawing.Size(104, 17);
             this.showSwagDataCB.TabIndex = 18;
-            this.showSwagDataCB.Text = "Animate Swag Z";
+            this.showSwagDataCB.Text = "Animate Swing Z";
             this.showSwagDataCB.UseVisualStyleBackColor = true;
             this.showSwagDataCB.CheckedChanged += new System.EventHandler(this.swagViewing_CheckedChanged);
             // 


### PR DESCRIPTION
One can now have passthrough angles calculated automatically by selecting the option in the context menu of the "Collisions" tree-node in the LVD Editor.

Currently, it determines which way a line is supposed to face by what angle it is set to at the time of calculation. This means that the best way to use this feature is by first setting an approximation of the desired angle for each line.

It is possible for the calculated angle to be the opposite of the desired angle, especially if the collision is ordered counter-clockwise. These issues could possibly be fixed if more advanced mathematical logic is implemented.

On a different note, I changed the checkboxes in Render Settings to say "Swing" (the correct term) instead of "Swag".