### PR TITLE
NUT and LVD fixes

### DIFF
--- a/Smash Forge/Filetypes/LVD.cs
+++ b/Smash Forge/Filetypes/LVD.cs
@@ -119,6 +119,42 @@ namespace Smash_Forge
         public float y;
     }
 
+    public enum CollisionMatType : byte
+    {
+        Brick = 0x00,
+        Rock = 0x01,
+        Grass = 0x02,
+        Soil = 0x03,
+        Wood = 0x04,
+        LightMetal = 0x05,
+        HeavyMetal = 0x06,
+        Carpet = 0x07,
+        Fence = 0x08,
+        MasterFortress = 0x09,
+        Water = 0x0a,
+        Bubbles = 0x0b,
+        Ice = 0x0c,
+        Snow = 0x0d,
+        SnowIce = 0x0e,
+        Gamewatch = 0x0f,
+        Ice2 = 0x10,
+        Danbouru = 0x11,
+        SpikesTargetTestOnly = 0x12, //Untested; from Brawl
+        Hazard2SSEOnly = 0x13, //Untested; from Brawl
+        Hazard3SSEOnly = 0x14, //Untested; from Brawl
+        LargeBubbles = 0x15,
+        Clouds = 0x16,
+        Subspace = 0x17, //Untested; from Brawl
+        Stone2 = 0x18,
+        Unknown2 = 0x19, //Untested; from Brawl
+        NES8Bit = 0x1a, //Untested; from Brawl
+        Metal2 = 0x1b,
+        Sand = 0x1c,
+        Homerun = 0x1d, //Untested; from Brawl
+        WaterNoSplash = 0x1e, //Untested; from Brawl
+        Hurt = 0x1f
+    }
+
     public class CollisionMat
     {
         public byte[] material = new byte[0xC];

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.Designer.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDEditor.Designer.cs
@@ -521,31 +521,6 @@
             // physicsMatComboBox
             // 
             this.physicsMatComboBox.FormattingEnabled = true;
-            this.physicsMatComboBox.Items.AddRange(new object[] {
-            "Iron",
-            "Snow",
-            "Ice",
-            "Wood",
-            "LargeBubbles",
-            "Hurt",
-            "Brick",
-            "Stone2",
-            "Metal2",
-            "Water",
-            "Bubbles",
-            "Clouds",
-            "Ice2",
-            "NebuIron",
-            "Danbouru",
-            "Rock",
-            "Gamewatch",
-            "Grass",
-            "SnowIce",
-            "Fence",
-            "Soil",
-            "Sand",
-            "MasterFortress",
-            "Carpet"});
             this.physicsMatComboBox.Location = new System.Drawing.Point(10, 396);
             this.physicsMatComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.physicsMatComboBox.Name = "physicsMatComboBox";

--- a/Smash Forge/GUI/Menus/PolygonFormatEditor.cs
+++ b/Smash Forge/GUI/Menus/PolygonFormatEditor.cs
@@ -69,7 +69,9 @@ namespace Smash_Forge
                 }
             }
 
-            vertexColorCB.Checked = poly.UVSize >> 4 != 0;
+            int uvCount = poly.UVSize >> 4;
+            int colorType = poly.UVSize & 0x0F;
+            vertexColorCB.Checked = colorType != 0;
         }
 
         private void applyButton_Click(object sender, EventArgs e)
@@ -105,18 +107,18 @@ namespace Smash_Forge
             int uvFlag = poly.UVSize;
             if (vertexColorCB.Checked)
             {
-                if (uvFlag >> 4 == 0)
+                if ((uvFlag & 0x0F) == 0)
                 {
-                    uvFlag = 0x10 | uvFlag;
+                    uvFlag = 0x02 | uvFlag;
                     foreach (NUD.Vertex v in poly.vertices)
                         v.color = new OpenTK.Vector4(127, 127, 127, 127);
                 }
             }
             else
             {
-                if (uvFlag >> 4 != 0)
+                if ((uvFlag & 0x0F) != 0)
                 {
-                    uvFlag &= 0x0F;
+                    uvFlag &= 0xF0;
                     foreach (NUD.Vertex v in poly.vertices)
                         v.color = new OpenTK.Vector4(127, 127, 127, 127);
                 }

--- a/Smash Forge/param_labels/stage_param.ini
+++ b/Smash Forge/param_labels/stage_param.ini
@@ -3,10 +3,6 @@ name=stprm
 group=1
 name=STPRM
 
-[Entry]
-group=1
-name=Stage Parameter
-
 [Value]
 group=1
 value=0
@@ -75,7 +71,7 @@ name=Vertical Rotation Factor
 [Value]
 group=1
 value=13
-name=Character Bubble Buffer Multiplier
+name=Hoop/Magnifying Glass Size Multiplier
 
 [Value]
 group=1
@@ -215,7 +211,7 @@ name=Fixed Cam Horizontal Angle
 [Value]
 group=1
 value=41
-name=Fixed Cam Verticle Angle
+name=Fixed Cam Vertical Angle
 
 [Value]
 group=1


### PR DESCRIPTION
- NUT fixes
  - Fixed importing of some DXT5 textures causing a game crash. For DXT5 textures that are not square, mipmap amount will now be limited to the maximum amount that will not cause a game crash. (Thanks to TNN, mOatles and DSX8 for assisting with this issue.)
  - Added importing of DXT3 texture format.
  - Fixed importing of RGBA texture format.
  - Fixed exporting of textures often resulting in partially-broken DDS files.
  - Fixed error upon opening certain nut files (e.g. "Baramoku" trophy). (Thanks to SMG for reporting this issue.)
- LVD fixes
  - Fixed error upon adding vertices to a collision that has none.
  - Updated collision physics material list. Several new types have been added, based on data from Brawl. (Thanks to [StageBox](https://github.com/soopercool101/stagebox)'s code for material names.)
- Fixed Polygon Format Editor setting vertex color flag incorrectly.
- Updated stprm param labels.