### PR TITLE
NUT IO and class updates

### DIFF
--- a/Smash Forge/Filetypes/Melee/DAT.cs
+++ b/Smash Forge/Filetypes/Melee/DAT.cs
@@ -659,10 +659,10 @@ namespace Smash_Forge
                 tex.Width = texturesLinker[key].Width;
                 tex.Height = texturesLinker[key].Height;
                 tex.HASHID = 0x401B1000 + texid;
-                tex.mipmaps = new List<byte[]>();
+                tex.surfaces.Add(new TextureSurface());
                 byte[] mip1 = ConvertBitmapToByteArray(texturesLinker[key]);
                 Console.WriteLine(mip1.Length);
-                tex.mipmaps.Add(mip1);
+                tex.surfaces[0].mipmaps.Add(mip1);
                 tex.type = PixelInternalFormat.Rgba;
                 tex.utype = PixelFormat.Bgra;
                 nut.Nodes.Add(tex);

--- a/Smash Forge/Filetypes/Textures/DDS.cs
+++ b/Smash Forge/Filetypes/Textures/DDS.cs
@@ -222,7 +222,7 @@ namespace Smash_Forge
             header.width = (uint)tex.Width;
             header.height = (uint)tex.Height;
             header.pitchOrLinearSize = (uint)tex.Size;
-            header.mipMapCount = (uint)tex.mipMapCount;
+            header.mipMapCount = (uint)tex.surfaces[0].mipmaps.Count;
             header.caps2 = tex.ddsCaps2;
             bool isCubemap = (header.caps2 & (uint)DDSCAPS2.CUBEMAP) == (uint)DDSCAPS2.CUBEMAP;
             header.caps = (uint)DDSCAPS.TEXTURE;
@@ -283,12 +283,12 @@ namespace Smash_Forge
             tex.HASHID = 0x48415348;
             tex.Height = (int)header.height;
             tex.Width = (int)header.width;
-            tex.surfaceCount = 1;
+            byte surfaceCount = 1;
             bool isCubemap = (header.caps2 & (uint)DDSCAPS2.CUBEMAP) == (uint)DDSCAPS2.CUBEMAP;
             if (isCubemap)
             {
                 if ((header.caps2 & (uint)DDSCAPS2.CUBEMAP_ALLFACES) == (uint)DDSCAPS2.CUBEMAP_ALLFACES)
-                    tex.surfaceCount = 6;
+                    surfaceCount = 6;
                 else
                     throw new NotImplementedException($"Unsupported cubemap face amount for texture. Six faces are required.");
             }
@@ -331,7 +331,7 @@ namespace Smash_Forge
                 header.mipMapCount = 1;
 
             uint off = 0;
-            for (int i = 0; i < tex.surfaceCount; ++i)
+            for (byte i = 0; i < surfaceCount; ++i)
             {
                 TextureSurface surface = new TextureSurface();
                 uint w = header.width, h = header.height;
@@ -360,7 +360,6 @@ namespace Smash_Forge
                 }
                 tex.surfaces.Add(surface);
             }
-            tex.mipMapCount = (byte)(tex.surfaces[0].mipmaps.Count);
 
             return tex;
         }

--- a/Smash Forge/Filetypes/Textures/DDS.cs
+++ b/Smash Forge/Filetypes/Textures/DDS.cs
@@ -270,7 +270,7 @@ namespace Smash_Forge
             }
 
             List<byte> d = new List<byte>();
-            foreach (byte[] b in tex.mipmaps)
+            foreach (byte[] b in tex.getAllMipmaps())
             {
                 d.AddRange(b);
             }
@@ -333,6 +333,7 @@ namespace Smash_Forge
             uint off = 0;
             for (int i = 0; i < tex.surfaceCount; ++i)
             {
+                TextureSurface surface = new TextureSurface();
                 uint w = header.width, h = header.height;
                 for (int j = 0; j < header.mipMapCount; ++j)
                 {
@@ -354,11 +355,12 @@ namespace Smash_Forge
 
                     w /= 2;
                     h /= 2;
-                    tex.mipmaps.Add(d.getSection((int)off, (int)s));
+                    surface.mipmaps.Add(d.getSection((int)off, (int)s));
                     off += s;
                 }
+                tex.surfaces.Add(surface);
             }
-            tex.mipMapCount = (byte)(tex.mipmaps.Count / tex.surfaceCount);
+            tex.mipMapCount = (byte)(tex.surfaces[0].mipmaps.Count);
 
             return tex;
         }

--- a/Smash Forge/GUI/Editors/NUTEditor.cs
+++ b/Smash Forge/GUI/Editors/NUTEditor.cs
@@ -337,13 +337,13 @@ namespace Smash_Forge
             switch (tex.utype)
             {
                 case OpenTK.Graphics.OpenGL.PixelFormat.Rgba:
-                    Pixel.fromRGBA(new FileData(tex.mipmaps[0]), tex.Width, tex.Height).Save(filename);
+                    Pixel.fromRGBA(new FileData(tex.surfaces[0].mipmaps[0]), tex.Width, tex.Height).Save(filename);
                     break;
                 case OpenTK.Graphics.OpenGL.PixelFormat.AbgrExt:
-                    Pixel.fromABGR(new FileData(tex.mipmaps[0]), tex.Width, tex.Height).Save(filename);
+                    Pixel.fromABGR(new FileData(tex.surfaces[0].mipmaps[0]), tex.Width, tex.Height).Save(filename);
                     break;
                 case OpenTK.Graphics.OpenGL.PixelFormat.Bgra:
-                    Pixel.fromBGRA(new FileData(tex.mipmaps[0]), tex.Width, tex.Height).Save(filename);
+                    Pixel.fromBGRA(new FileData(tex.surfaces[0].mipmaps[0]), tex.Width, tex.Height).Save(filename);
                     break;
                 default:
                     RenderTextureToPng(tex, filename, true, true, true, true);
@@ -423,12 +423,13 @@ namespace Smash_Forge
             Bitmap bmp = new Bitmap(fname);
             NutTexture tex = new NutTexture();
 
-            tex.mipmaps.Add(fromPNG(bmp));
+            tex.surfaces.Add(new TextureSurface());
+            tex.surfaces[0].mipmaps.Add(fromPNG(bmp));
             tex.mipMapCount = 1;
             for (int i = 1; i < mipcount; i++)
             {
                 if (bmp.Width / (int)Math.Pow(2, i) < 4 || bmp.Height / (int)Math.Pow(2, i) < 4) break;
-                tex.mipmaps.Add(fromPNG(Pixel.ResizeImage(bmp, bmp.Width / (int)Math.Pow(2, i), bmp.Height / (int)Math.Pow(2, i))));
+                tex.surfaces[0].mipmaps.Add(fromPNG(Pixel.ResizeImage(bmp, bmp.Width / (int)Math.Pow(2, i), bmp.Height / (int)Math.Pow(2, i))));
                 ++tex.mipMapCount;
             }
             tex.Width = bmp.Width;
@@ -531,7 +532,7 @@ namespace Smash_Forge
                     texture.type = newTexture.type;
                     texture.mipMapCount = newTexture.mipMapCount;
                     texture.surfaceCount = newTexture.surfaceCount;
-                    texture.mipmaps = newTexture.mipmaps;
+                    texture.surfaces = newTexture.surfaces;
                     texture.utype = newTexture.utype;
 
                     Edited = true;
@@ -686,7 +687,7 @@ namespace Smash_Forge
                 tex.type = ntex.type;
                 tex.mipMapCount = ntex.mipMapCount;
                 tex.surfaceCount = ntex.surfaceCount;
-                tex.mipmaps = ntex.mipmaps;
+                tex.surfaces = ntex.surfaces;
                 tex.utype = ntex.utype;
 
                 GL.DeleteTexture(NUT.glTexByHashId[tex.HASHID]);
@@ -806,7 +807,7 @@ namespace Smash_Forge
                             tex.type = ntex.type;
                             tex.mipMapCount = ntex.mipMapCount;
                             tex.surfaceCount = ntex.surfaceCount;
-                            tex.mipmaps = ntex.mipmaps;
+                            tex.surfaces = ntex.surfaces;
                             tex.utype = ntex.utype;
 
                             GL.DeleteTexture(NUT.glTexByHashId[tex.HASHID]);

--- a/Smash Forge/GUI/Editors/NUTEditor.cs
+++ b/Smash Forge/GUI/Editors/NUTEditor.cs
@@ -174,8 +174,8 @@ namespace Smash_Forge
                 heightLabel.Text = "Height:" + tex.Height;
 
                 // Get number of mip maps for current texture.
-                mipLevelTrackBar.Maximum = (tex.mipMapCount) - 1;
-                maxMipLevelLabel.Text = "Total:" + tex.mipMapCount + "";
+                mipLevelTrackBar.Maximum = (tex.surfaces[0].mipmaps.Count) - 1;
+                maxMipLevelLabel.Text = "Total:" + tex.surfaces[0].mipmaps.Count + "";
             }
             else
             {
@@ -331,7 +331,7 @@ namespace Smash_Forge
 
         private void ExportPNG(string filename, NutTexture tex)
         {
-            if (tex.mipMapCount > 1)
+            if (tex.surfaces[0].mipmaps.Count > 1)
                 MessageBox.Show("Note: Textures exported as PNG do not preserve mipmaps.");
 
             switch (tex.utype)
@@ -425,12 +425,10 @@ namespace Smash_Forge
 
             tex.surfaces.Add(new TextureSurface());
             tex.surfaces[0].mipmaps.Add(fromPNG(bmp));
-            tex.mipMapCount = 1;
             for (int i = 1; i < mipcount; i++)
             {
                 if (bmp.Width / (int)Math.Pow(2, i) < 4 || bmp.Height / (int)Math.Pow(2, i) < 4) break;
                 tex.surfaces[0].mipmaps.Add(fromPNG(Pixel.ResizeImage(bmp, bmp.Width / (int)Math.Pow(2, i), bmp.Height / (int)Math.Pow(2, i))));
-                ++tex.mipMapCount;
             }
             tex.Width = bmp.Width;
             tex.Height = bmp.Height;
@@ -530,8 +528,6 @@ namespace Smash_Forge
                     texture.Height = newTexture.Height;
                     texture.Width = newTexture.Width;
                     texture.type = newTexture.type;
-                    texture.mipMapCount = newTexture.mipMapCount;
-                    texture.surfaceCount = newTexture.surfaceCount;
                     texture.surfaces = newTexture.surfaces;
                     texture.utype = newTexture.utype;
 
@@ -685,8 +681,6 @@ namespace Smash_Forge
                 tex.Height = ntex.Height;
                 tex.Width = ntex.Width;
                 tex.type = ntex.type;
-                tex.mipMapCount = ntex.mipMapCount;
-                tex.surfaceCount = ntex.surfaceCount;
                 tex.surfaces = ntex.surfaces;
                 tex.utype = ntex.utype;
 
@@ -805,8 +799,6 @@ namespace Smash_Forge
                             tex.Height = ntex.Height;
                             tex.Width = ntex.Width;
                             tex.type = ntex.type;
-                            tex.mipMapCount = ntex.mipMapCount;
-                            tex.surfaceCount = ntex.surfaceCount;
                             tex.surfaces = ntex.surfaces;
                             tex.utype = ntex.utype;
 

--- a/Smash Forge/GUI/Editors/UIPreview.cs
+++ b/Smash Forge/GUI/Editors/UIPreview.cs
@@ -78,7 +78,8 @@ namespace Smash_Forge
             NutTexture tex = new NutTexture();
             tex.Width = view.shootWidth;
             tex.Height = view.shootHeight;
-            tex.mipmaps.Add(FlipDXT5(data, tex.Width, tex.Height));
+            tex.surfaces.Add(new TextureSurface());
+            tex.surfaces[0].mipmaps.Add(FlipDXT5(data, tex.Width, tex.Height));
             tex.type = PixelInternalFormat.CompressedRgbaS3tcDxt5Ext;
             tex.HASHID = id;
             n.Nodes.Add(tex);

--- a/Smash Forge/IO/FileOutput.cs
+++ b/Smash Forge/IO/FileOutput.cs
@@ -120,12 +120,6 @@ namespace Smash_Forge
                 writeByte(v);
         }
 
-        /*public void align(int i, int value){
-            while(data.size() % i != 0)
-                writeByte(value);
-        }*/
-
-
         public void writeFloat(float f){
             int i = SingleToInt32Bits (f, Endian == Endianness.Big);
             data.Add((byte)((i)&0xFF));
@@ -169,7 +163,21 @@ namespace Smash_Forge
             }
         }
 
+        public void writeUShort(ushort i){
+            if(Endian == Endianness.Little){
+                data.Add((byte)((i)&0xFF));
+                data.Add((byte)((i>>8)&0xFF));
+            } else {
+                data.Add((byte)((i>>8)&0xFF));
+                data.Add((byte)((i)&0xFF));
+            }
+        }
+
         public void writeByte(int i){
+            data.Add((byte)((i)&0xFF));
+        }
+
+        public void writeSByte(sbyte i){
             data.Add((byte)((i)&0xFF));
         }
 


### PR DESCRIPTION
- NUT refactoring:
  - New class, ``TextureSurface``, and new ``NutTexture`` member, ``public List<TextureSurface> surfaces``, to replace the old ``public List<byte[]> mipmaps``. ``TextureSurface`` contains an equivalent member to ``mipmaps``. Image data is now accessed as ``texture.surfaces[i].mipmaps[j]``, where there is 1 surface for most textures and 6 surfaces for cubemaps.
  - New functions, ``void swapChannelOrderUp()`` and ``void swapChannelOrderDown()``, which replace certain code snippets of the IO functions. They are intended to be called only from within said IO functions.
  - Refactor GTX NUT IO code to partially add support for cubemaps.
  - Changed integer type and/or signage for several variables throughout the NUT IO code.
- FileOutput
  - New functions: ``void writeUShort(ushort i)`` and ``void writeSByte(sbyte i)``.
  - I have not currently changed any existing FileOutput functions, but in the future I would like to update them to take more appropriate integer types for their respective arguments.