### PR TITLE
Bugfixes; rename bounding box to bounding sphere

### DIFF
--- a/Smash Forge/Filetypes/Application/Config.cs
+++ b/Smash Forge/Filetypes/Application/Config.cs
@@ -179,8 +179,8 @@ namespace Smash_Forge
                     case "render_tether_ledge_grabboxes":
                         bool.TryParse(node.InnerText, out Runtime.renderTetherLedgeGrabboxes);
                         break;
-                    case "render_bounding_boxes":
-                        bool.TryParse(node.InnerText, out Runtime.renderBoundingBox);
+                    case "render_bounding_spheres":
+                        bool.TryParse(node.InnerText, out Runtime.renderBoundingSphere);
                         break;
                     case "render_path":
                         bool.TryParse(node.InnerText, out Runtime.renderPath);
@@ -440,7 +440,7 @@ namespace Smash_Forge
             renderModelNode.AppendChild(createNode(doc, "render_selection", Runtime.renderModelSelection.ToString()));
             renderModelNode.AppendChild(createNode(doc, "render_wireframe", Runtime.renderModelWireframe.ToString()));
             renderModelNode.AppendChild(createNode(doc, "render_bones", Runtime.renderBones.ToString()));
-            renderModelNode.AppendChild(createNode(doc, "render_bounding_boxes", Runtime.renderBoundingBox.ToString()));
+            renderModelNode.AppendChild(createNode(doc, "render_bounding_spheres", Runtime.renderBoundingSphere.ToString()));
         }
 
         private static void AppendMaterialLightingSettings(XmlDocument doc, XmlNode parentNode)

--- a/Smash Forge/Filetypes/Models/ModelContainer.cs
+++ b/Smash Forge/Filetypes/Models/ModelContainer.cs
@@ -479,7 +479,7 @@ namespace Smash_Forge
                 Vector3 closest = Vector3.Zero;
                 foreach (NUD.Mesh mesh in NUD.Nodes)
                 {
-                    if (ray.CheckSphereHit(new Vector3(mesh.boundingBox[0], mesh.boundingBox[1], mesh.boundingBox[2]), mesh.boundingBox[3], out closest))
+                    if (ray.CheckSphereHit(new Vector3(mesh.boundingSphere[0], mesh.boundingSphere[1], mesh.boundingSphere[2]), mesh.boundingSphere[3], out closest))
                         selected.Add(ray.Distance(closest), mesh);
                 }
             }

--- a/Smash Forge/Filetypes/Models/NUD.cs
+++ b/Smash Forge/Filetypes/Models/NUD.cs
@@ -42,7 +42,7 @@ namespace Smash_Forge
         public int type = SMASH;
         public int boneCount = 0;
         public bool hasBones = false;
-        public float[] boundingBox = new float[4];
+        public float[] boundingSphere = new float[4];
 
         // Just used for rendering.
         private List<Mesh> depthSortedMeshes = new List<Mesh>();
@@ -330,8 +330,8 @@ namespace Smash_Forge
             }
 
             // Main function for NUD rendering.
-            if (Runtime.renderBoundingBox)
-                DrawBoundingBoxes();
+            if (Runtime.renderBoundingSphere)
+                DrawBoundingSpheres();
 
             // Choose the correct shader.
             Shader shader;
@@ -377,13 +377,13 @@ namespace Smash_Forge
             }
         }
 
-        private void DrawBoundingBoxes()
+        private void DrawBoundingSpheres()
         {
             GL.UseProgram(0);
 
             // Draw NUD bounding box. 
             GL.Color4(Color.GhostWhite);
-            RenderTools.DrawCube(new Vector3(boundingBox[0], boundingBox[1], boundingBox[2]), boundingBox[3], true);
+            RenderTools.DrawCube(new Vector3(boundingSphere[0], boundingSphere[1], boundingSphere[2]), boundingSphere[3], true);
 
             // Draw all the mesh bounding boxes. Selected: White. Deselected: Orange.
             foreach (Mesh mesh in Nodes)
@@ -399,20 +399,20 @@ namespace Smash_Forge
                     {
                         // Use the center of the bone as the bounding box center for NSC meshes. 
                         Vector3 center = ((ModelContainer)Parent).VBN.bones[mesh.singlebind].pos;
-                        RenderTools.DrawCube(center, mesh.boundingBox[3], true);
+                        RenderTools.DrawCube(center, mesh.boundingSphere[3], true);
                     }
                     else
                     {
-                        RenderTools.DrawCube(new Vector3(mesh.boundingBox[0], mesh.boundingBox[1], mesh.boundingBox[2]), mesh.boundingBox[3], true);
+                        RenderTools.DrawCube(new Vector3(mesh.boundingSphere[0], mesh.boundingSphere[1], mesh.boundingSphere[2]), mesh.boundingSphere[3], true);
                     }
                 }
             }
         }
 
-        public void GenerateBoundingBoxes()
+        public void GenerateBoundingSpheres()
         {
             foreach (Mesh m in Nodes)
-                m.generateBoundingBox();
+                m.generateBoundingSphere();
 
             Vector3 cen1 = new Vector3(0,0,0), cen2 = new Vector3(0,0,0);
             double rad1 = 0, rad2 = 0;
@@ -501,9 +501,9 @@ namespace Smash_Forge
             //Set
             for (int i = 0; i < 3; i++)
             {
-                boundingBox[i] = temp[i];
+                boundingSphere[i] = temp[i];
             }
-            boundingBox[3] = (float)radius;
+            boundingSphere[3] = (float)radius;
         }
 
         public void SetPropertiesFromXMB(XMBFile xmb)
@@ -1295,7 +1295,7 @@ namespace Smash_Forge
                                 Buffer.BlockCopy(matHashFloat, 0, bytes, 0, 4);
                                 int matHash = BitConverter.ToInt32(bytes, 0);
 
-                                int frm = (int)((frame * 60 / m.frameRate) % (m.numFrames));
+                                int frm = (int)((frame * 60 / m.frameRate) % (m.frameCount));
 
                                 if (matHash == matEntry.matHash || matHash == matEntry.matHash2)
                                 {
@@ -1392,28 +1392,28 @@ namespace Smash_Forge
             int vertaddClumpStart = vertClumpStart + vertClumpSize;
             int vertaddClumpSize = fileData.readInt();
             int nameStart = vertaddClumpStart + vertaddClumpSize;
-            boundingBox[0] = fileData.readFloat();
-            boundingBox[1] = fileData.readFloat();
-            boundingBox[2] = fileData.readFloat();
-            boundingBox[3] = fileData.readFloat();
+            boundingSphere[0] = fileData.readFloat();
+            boundingSphere[1] = fileData.readFloat();
+            boundingSphere[2] = fileData.readFloat();
+            boundingSphere[3] = fileData.readFloat();
 
             // object descriptors
 
             ObjectData[] obj = new ObjectData[polysets];
-            List<float[]> boundingBoxes = new List<float[]>();
+            List<float[]> boundingSpheres = new List<float[]>();
             int[] boneflags = new int[polysets];
             for (int i = 0; i < polysets; i++)
             {
-                float[] boundingBox = new float[8];
-                boundingBox[0] = fileData.readFloat();
-                boundingBox[1] = fileData.readFloat();
-                boundingBox[2] = fileData.readFloat();
-                boundingBox[3] = fileData.readFloat();
-                boundingBox[4] = fileData.readFloat();
-                boundingBox[5] = fileData.readFloat();
-                boundingBox[6] = fileData.readFloat();
-                boundingBox[7] = fileData.readFloat();
-                boundingBoxes.Add(boundingBox);
+                float[] boundingSphere = new float[8];
+                boundingSphere[0] = fileData.readFloat();
+                boundingSphere[1] = fileData.readFloat();
+                boundingSphere[2] = fileData.readFloat();
+                boundingSphere[3] = fileData.readFloat();
+                boundingSphere[4] = fileData.readFloat();
+                boundingSphere[5] = fileData.readFloat();
+                boundingSphere[6] = fileData.readFloat();
+                boundingSphere[7] = fileData.readFloat();
+                boundingSpheres.Add(boundingSphere);
                 int temp = fileData.pos() + 4;
                 fileData.seek(nameStart + fileData.readInt());
                 obj[i].name = (fileData.readString());
@@ -1434,7 +1434,7 @@ namespace Smash_Forge
                 Nodes.Add(m);
                 m.boneflag = boneflags[meshIndex];
                 m.singlebind = (short)o.singlebind;
-                m.boundingBox = boundingBoxes[meshIndex++];
+                m.boundingSphere = boundingSpheres[meshIndex++];
 
                 for (int i = 0; i < o.polyCount; i++)
                 {
@@ -1775,10 +1775,10 @@ namespace Smash_Forge
             d.writeInt(0); // vertexClumpsize
             d.writeInt(0); // vertexaddclump size
             
-            d.writeFloat(boundingBox[0]);
-            d.writeFloat(boundingBox[1]);
-            d.writeFloat(boundingBox[2]);
-            d.writeFloat(boundingBox[3]);
+            d.writeFloat(boundingSphere[0]);
+            d.writeFloat(boundingSphere[1]);
+            d.writeFloat(boundingSphere[2]);
+            d.writeFloat(boundingSphere[3]);
 
             // other sections....
             FileOutput obj = new FileOutput();
@@ -1811,7 +1811,7 @@ namespace Smash_Forge
 
             foreach (Mesh m in Nodes)
             {
-                foreach (float f in m.boundingBox)
+                foreach (float f in m.boundingSphere)
                     d.writeFloat(f);
 
                 d.writeInt(tempstring.size());
@@ -3065,7 +3065,7 @@ namespace Smash_Forge
             public bool useNsc = false;
 
             public bool sortByObjHeirarchy = true;
-            public float[] boundingBox = new float[8];
+            public float[] boundingSphere = new float[8];
             public float sortingDistance = 0;
 
             public Mesh()
@@ -3097,7 +3097,7 @@ namespace Smash_Forge
                 ((Polygon)Nodes[0]).AddVertex(v);
             }
 
-            public void generateBoundingBox()
+            public void generateBoundingSphere()
             {
                 Vector3 cen1 = new Vector3(0,0,0), cen2 = new Vector3(0,0,0);
                 double rad1 = 0, rad2 = 0;
@@ -3176,16 +3176,16 @@ namespace Smash_Forge
                 // Set
                 for (int i = 0; i < 3; i++)
                 {
-                    boundingBox[i] = temp[i];
-                    boundingBox[i+4] = temp[i];
+                    boundingSphere[i] = temp[i];
+                    boundingSphere[i+4] = temp[i];
                 }
-                boundingBox[3] = (float)radius;
-                boundingBox[7] = 0;
+                boundingSphere[3] = (float)radius;
+                boundingSphere[7] = 0;
             }
 
             public float CalculateSortingDistance(Vector3 cameraPosition)
             {
-                Vector3 meshCenter = new Vector3(boundingBox[0], boundingBox[1], boundingBox[2]);
+                Vector3 meshCenter = new Vector3(boundingSphere[0], boundingSphere[1], boundingSphere[2]);
                 if (useNsc && singlebind != -1)
                 {
                     // Use the bone position as the bounding box center
@@ -3194,7 +3194,7 @@ namespace Smash_Forge
                 }
 
                 Vector3 distanceVector = new Vector3(cameraPosition - meshCenter);
-                return distanceVector.Length + boundingBox[3] + sortBias;
+                return distanceVector.Length + boundingSphere[3] + sortBias;
             }
 
             private int CalculateSortBias()

--- a/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
+++ b/Smash Forge/GUI/Editors/LVD Editor/LVDList.cs
@@ -200,7 +200,14 @@ namespace Smash_Forge
             ElementCM.MenuItems.Add(Delete);
 
             CollisionCM = new ContextMenu();
+
+            Delete = new MenuItem("Delete Entry");
+            Delete.Click += delegate
+            {
+                deleteSelected();
+            };
             CollisionCM.MenuItems.Add(Delete);
+
             MenuItem GenPassthru = new MenuItem("Regenerate Passthrough Angles");
             GenPassthru.Click += delegate
             {

--- a/Smash Forge/GUI/Editors/MeshList.Designer.cs
+++ b/Smash Forge/GUI/Editors/MeshList.Designer.cs
@@ -95,7 +95,7 @@
             this.recalculateToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
             this.smoothToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
             this.generateTanBitanToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.generateBoundingBoxesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.generateBoundingSpheresToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openEditToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.vertexColorToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
             this.setToWhiteToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
@@ -551,7 +551,7 @@
             this.addBlankMeshToolStripMenuItem,
             this.smoothNormalsToolStripMenuItem1,
             this.generateTanBitanToolStripMenuItem,
-            this.generateBoundingBoxesToolStripMenuItem,
+            this.generateBoundingSpheresToolStripMenuItem,
             this.openEditToolStripMenuItem,
             this.vertexColorToolStripMenuItem2});
             this.nudContextMenu.Name = "nudContextMenu";
@@ -652,12 +652,12 @@
             this.generateTanBitanToolStripMenuItem.Text = "Generate Tan/Bitan";
             this.generateTanBitanToolStripMenuItem.Click += new System.EventHandler(this.generateTanBitanToolStripMenuItem_Click);
             // 
-            // generateBoundingBoxesToolStripMenuItem
+            // generateBoundingSpheresToolStripMenuItem
             // 
-            this.generateBoundingBoxesToolStripMenuItem.Name = "generateBoundingBoxesToolStripMenuItem";
-            this.generateBoundingBoxesToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
-            this.generateBoundingBoxesToolStripMenuItem.Text = "Generate Bounding Boxes";
-            this.generateBoundingBoxesToolStripMenuItem.Click += new System.EventHandler(this.generateBoundingBoxesToolStripMenuItem_Click);
+            this.generateBoundingSpheresToolStripMenuItem.Name = "generateBoundingSpheresToolStripMenuItem";
+            this.generateBoundingSpheresToolStripMenuItem.Size = new System.Drawing.Size(209, 22);
+            this.generateBoundingSpheresToolStripMenuItem.Text = "Generate Bounding Spheres";
+            this.generateBoundingSpheresToolStripMenuItem.Click += new System.EventHandler(this.generateBoundingSpheresToolStripMenuItem_Click);
             // 
             // openEditToolStripMenuItem
             // 
@@ -867,7 +867,7 @@
         private System.Windows.Forms.ToolStripMenuItem exportAsDAEToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem importFromDAEToolStripMenuItem;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.ToolStripMenuItem generateBoundingBoxesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem generateBoundingSpheresToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
         private System.Windows.Forms.ToolStripMenuItem calculateNormalsToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem recalculateToolStripMenuItem;

--- a/Smash Forge/GUI/Editors/MeshList.cs
+++ b/Smash Forge/GUI/Editors/MeshList.cs
@@ -886,9 +886,9 @@ namespace Smash_Forge
             }
         }
 
-        private void generateBoundingBoxesToolStripMenuItem_Click(object sender, EventArgs e)
+        private void generateBoundingSpheresToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            ((NUD)filesTreeView.SelectedNode).GenerateBoundingBoxes();
+            ((NUD)filesTreeView.SelectedNode).GenerateBoundingSpheres();
         }
 
         private void recalculateToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Smash Forge/GUI/MainForm.cs
+++ b/Smash Forge/GUI/MainForm.cs
@@ -1152,7 +1152,7 @@ namespace Smash_Forge
                 }else
                 {
                     mvp.ViewComboBox.SelectedItem = "LVD Editor";
-                    mvp.Text = fileName;
+                    mvp.Text = Path.GetFileName(fileName);
                     mvp.LVD = new LVD(fileName);
                 }
             }

--- a/Smash Forge/GUI/Menus/DAEImportSettings.cs
+++ b/Smash Forge/GUI/Menus/DAEImportSettings.cs
@@ -71,7 +71,7 @@ namespace Smash_Forge
 
         public void Apply(NUD nud)
         {
-            nud.GenerateBoundingBoxes();
+            nud.GenerateBoundingSpheres();
             Matrix4 rotXBy90 = Matrix4.CreateRotationX(0.5f * (float)Math.PI);
             float scale = 1f;
             bool hasScale = float.TryParse(scaleTB.Text, out scale);

--- a/Smash Forge/GUI/Menus/RenderSettings.cs
+++ b/Smash Forge/GUI/Menus/RenderSettings.cs
@@ -38,7 +38,7 @@ namespace Smash_Forge.GUI
 
             // Model Settings
             renderModelCB.Checked = Runtime.renderModel;
-            boundingCB.Checked = Runtime.renderBoundingBox;
+            boundingCB.Checked = Runtime.renderBoundingSphere;
             wireframeCB.Checked = Runtime.renderModelWireframe;
             modelSelectCB.Checked = Runtime.renderModelSelection;
             wireframeCB.Enabled = renderModelCB.Checked;
@@ -413,7 +413,7 @@ namespace Smash_Forge.GUI
 
         private void boundingCB_CheckedChanged(object sender, EventArgs e)
         {
-            Runtime.renderBoundingBox = boundingCB.Checked;
+            Runtime.renderBoundingSphere = boundingCB.Checked;
         }
 
         private void modelSelectCB_CheckedChanged(object sender, EventArgs e)

--- a/Smash Forge/GUI/ModelViewport.cs
+++ b/Smash Forge/GUI/ModelViewport.cs
@@ -129,9 +129,9 @@ namespace Smash_Forge
                 ResetModels();
                 currentAnimation = null;
                 currentMaterialAnimation = value;
-                totalFrame.Value = value.numFrames;
+                totalFrame.Value = value.frameCount;
                 animationTrackBar.TickFrequency = 1;
-                animationTrackBar.SetRange(0, (int)value.numFrames);
+                animationTrackBar.SetRange(0, (int)value.frameCount);
                 currentFrame.Value = 1;
                 currentFrame.Value = 0;
             }
@@ -788,61 +788,61 @@ namespace Smash_Forge
         private void FrameSelectedModelContainer()
         {
             ModelContainer modelContainer = (ModelContainer)meshList.filesTreeView.SelectedNode;
-            float[] boundingBox = new float[] { 0, 0, 0, 0 };
+            float[] boundingSphere = new float[] { 0, 0, 0, 0 };
 
             // Use the main bounding box for the NUD.
-            if (modelContainer.NUD.boundingBox[3] > boundingBox[3])
+            if (modelContainer.NUD.boundingSphere[3] > boundingSphere[3])
             {
-                boundingBox[0] = modelContainer.NUD.boundingBox[0];
-                boundingBox[1] = modelContainer.NUD.boundingBox[1];
-                boundingBox[2] = modelContainer.NUD.boundingBox[2];
-                boundingBox[3] = modelContainer.NUD.boundingBox[3];
+                boundingSphere[0] = modelContainer.NUD.boundingSphere[0];
+                boundingSphere[1] = modelContainer.NUD.boundingSphere[1];
+                boundingSphere[2] = modelContainer.NUD.boundingSphere[2];
+                boundingSphere[3] = modelContainer.NUD.boundingSphere[3];
             }
 
             // It's possible that only the individual meshes have bounding boxes.
             foreach (NUD.Mesh mesh in modelContainer.NUD.Nodes)
             {
-                if (mesh.boundingBox[3] > boundingBox[3])
+                if (mesh.boundingSphere[3] > boundingSphere[3])
                 {
-                    boundingBox[0] = mesh.boundingBox[0];
-                    boundingBox[1] = mesh.boundingBox[1];
-                    boundingBox[2] = mesh.boundingBox[2];
-                    boundingBox[3] = mesh.boundingBox[3];
+                    boundingSphere[0] = mesh.boundingSphere[0];
+                    boundingSphere[1] = mesh.boundingSphere[1];
+                    boundingSphere[2] = mesh.boundingSphere[2];
+                    boundingSphere[3] = mesh.boundingSphere[3];
                 }
             }
 
-            camera.FrameBoundingSphere(new Vector3(boundingBox[0], boundingBox[1], boundingBox[2]), boundingBox[3]);
+            camera.FrameBoundingSphere(new Vector3(boundingSphere[0], boundingSphere[1], boundingSphere[2]), boundingSphere[3]);
             camera.UpdateFromMouse();
         }
 
         private void FrameSelectedMesh()
         {
             NUD.Mesh mesh = (NUD.Mesh)meshList.filesTreeView.SelectedNode;
-            float[] boundingBox = mesh.boundingBox;
-            camera.FrameBoundingSphere(new Vector3(boundingBox[0], boundingBox[1], boundingBox[2]), boundingBox[3]);
+            float[] boundingSphere = mesh.boundingSphere;
+            camera.FrameBoundingSphere(new Vector3(boundingSphere[0], boundingSphere[1], boundingSphere[2]), boundingSphere[3]);
             camera.UpdateFromMouse();
         }
 
         private void FrameSelectedNud()
         {
             NUD nud = (NUD)meshList.filesTreeView.SelectedNode;
-            float[] boundingBox = nud.boundingBox;
-            camera.FrameBoundingSphere(new Vector3(boundingBox[0], boundingBox[1], boundingBox[2]), boundingBox[3]);
+            float[] boundingSphere = nud.boundingSphere;
+            camera.FrameBoundingSphere(new Vector3(boundingSphere[0], boundingSphere[1], boundingSphere[2]), boundingSphere[3]);
             camera.UpdateFromMouse();
         }
 
         private void FrameSelectedPolygon()
         {
             NUD.Mesh mesh = (NUD.Mesh)meshList.filesTreeView.SelectedNode.Parent;
-            float[] boundingBox = mesh.boundingBox;
-            camera.FrameBoundingSphere(new Vector3(boundingBox[0], boundingBox[1], boundingBox[2]), boundingBox[3]);
+            float[] boundingSphere = mesh.boundingSphere;
+            camera.FrameBoundingSphere(new Vector3(boundingSphere[0], boundingSphere[1], boundingSphere[2]), boundingSphere[3]);
             camera.UpdateFromMouse();
         }
 
         private void FrameAllModelContainers(float maxBoundingRadius = 400)
         {
             // Find the max NUD bounding box for all models. 
-            float[] boundingBox = new float[] { 0, 0, 0, 0 };
+            float[] boundingSphere = new float[] { 0, 0, 0, 0 };
             foreach (TreeNode node in meshList.filesTreeView.Nodes)
             {
                 if (node is ModelContainer)
@@ -850,30 +850,30 @@ namespace Smash_Forge
                     ModelContainer modelContainer = (ModelContainer)node;
 
                     // Use the main bounding box for the NUD.
-                    if ((modelContainer.NUD.boundingBox[3] > boundingBox[3]) && (modelContainer.NUD.boundingBox[3] < maxBoundingRadius))
+                    if ((modelContainer.NUD.boundingSphere[3] > boundingSphere[3]) && (modelContainer.NUD.boundingSphere[3] < maxBoundingRadius))
                     {
-                        boundingBox[0] = modelContainer.NUD.boundingBox[0];
-                        boundingBox[1] = modelContainer.NUD.boundingBox[1];
-                        boundingBox[2] = modelContainer.NUD.boundingBox[2];
-                        boundingBox[3] = modelContainer.NUD.boundingBox[3];
+                        boundingSphere[0] = modelContainer.NUD.boundingSphere[0];
+                        boundingSphere[1] = modelContainer.NUD.boundingSphere[1];
+                        boundingSphere[2] = modelContainer.NUD.boundingSphere[2];
+                        boundingSphere[3] = modelContainer.NUD.boundingSphere[3];
                     }
 
                     // It's possible that only the individual meshes have bounding boxes.
                     foreach (NUD.Mesh mesh in modelContainer.NUD.Nodes)
                     {
-                        if (mesh.boundingBox[3] > boundingBox[3] && mesh.boundingBox[3] < maxBoundingRadius)
+                        if (mesh.boundingSphere[3] > boundingSphere[3] && mesh.boundingSphere[3] < maxBoundingRadius)
                         {
-                            boundingBox[0] = mesh.boundingBox[0];
-                            boundingBox[1] = mesh.boundingBox[1];
-                            boundingBox[2] = mesh.boundingBox[2];
-                            boundingBox[3] = mesh.boundingBox[3];
+                            boundingSphere[0] = mesh.boundingSphere[0];
+                            boundingSphere[1] = mesh.boundingSphere[1];
+                            boundingSphere[2] = mesh.boundingSphere[2];
+                            boundingSphere[3] = mesh.boundingSphere[3];
                         }
                     }
                 }
 
             }
 
-            camera.FrameBoundingSphere(new Vector3(boundingBox[0], boundingBox[1], boundingBox[2]), boundingBox[3]);
+            camera.FrameBoundingSphere(new Vector3(boundingSphere[0], boundingSphere[1], boundingSphere[2]), boundingSphere[3]);
             camera.UpdateFromMouse();
         }
 

--- a/Smash Forge/Runtime.cs
+++ b/Smash Forge/Runtime.cs
@@ -90,7 +90,7 @@ namespace Smash_Forge
         public static bool renderOtherLVDEntries = true;
         public static bool renderSwagZ = false;
         public static bool renderSwagY = false;
-        public static bool renderBoundingBox;
+        public static bool renderBoundingSphere;
         public static bool renderHurtboxes = true;
         public static bool renderHurtboxesZone = true;
         public static bool renderECB = false;


### PR DESCRIPTION
- LVD bugfixes:
  - Fixed context menu not appearing for entries other than collisions.
  - The viewport tab now displays the file name of the lvd file, rather than the full path of it.
- MTA updates to class members:
  - One of the unknowns in ``MatData`` has been renamed to ``animType``, and an enum has been added representing its possible values.
  - ``startFrame`` and ``endFrame`` are now read and stored. When compiling an MTA, they are set automatically, as they are not included in the decompilation.
  - Renamed ``numFrames`` in the ``MTA`` class to ``frameCount``.
- In the context of NUD, rename "bounding box" to "bounding sphere". I have reviewed each occurence that has been replaced to check that nothing is broken.