### PR TITLE
Fix bfres textures from displaying

### DIFF
--- a/Smash Forge/Filetypes/BFRES/BFRES_Main.cs
+++ b/Smash Forge/Filetypes/BFRES/BFRES_Main.cs
@@ -895,22 +895,25 @@ namespace Smash_Forge
                 {
                     if (bntx.glTexByName.TryGetValue(tex.Name, out texture))
                     {
-                        BindBRTTexture(tex, texture);
+                        BindGLTexture(tex, texture);
                     }
                 }
             }
             else
             {
-                if (FTEXtextures.ContainsKey(tex.Name))
+                foreach (FTEXContainer ftexC in Runtime.FTEXContainerList)
                 {
-                    //  BindBRTTexture(tex, FTEXtextures[tex.Name].texture.display);
+                    if (ftexC.glTexByName.TryGetValue(tex.Name, out texture))
+                    {
+                        BindGLTexture(tex, texture);
+                    }
                 }
             }
 
             return tex.hash + 1;
         }
 
-        private static void BindBRTTexture(MatTexture matTexture, SFGraphics.GLObjects.Textures.Texture texture)
+        private static void BindGLTexture(MatTexture matTexture, SFGraphics.GLObjects.Textures.Texture texture)
         {
             // Set the texture's parameters based on the material settings.
             texture.Bind();

--- a/Smash Forge/Filetypes/BFRES/WiiU/FTEX.cs
+++ b/Smash Forge/Filetypes/BFRES/WiiU/FTEX.cs
@@ -25,7 +25,10 @@ namespace Smash_Forge
 
             foreach (FTEX tex in FTEXtextures.Values)
             {
-                glTexByName.Add(tex.Text, FTEX.CreateTexture2D(tex.texture));
+                SFTex.Texture2D texture2d = FTEX.CreateTexture2D(tex.texture);
+                glTexByName.Add(tex.Text, texture2d);
+
+                tex.texture.display = texture2d.Id;
                 tex.display = tex.texture.display;
             }
         }
@@ -57,11 +60,25 @@ namespace Smash_Forge
             texture.data = GTX.swizzleBC(tex.Data, texture.width, texture.height, format, (int)tex.TileMode, pitch, swizzle);
             Text = tex.Name;
 
+
             //Setup variables for treenode data
 
             width = texture.width;
             height = texture.height;
             texture.mipMapCount = (int)tex.MipCount;
+
+            FileData f = new FileData(tex.MipData);
+            for (int level = 0; level < tex.MipCount; level++)
+            {
+                if (level != 0)
+                {
+
+                }
+
+                //  byte[] mip = f.getSection((int)tex.MipOffsets[level - 1], (int)tex.MipOffsets[level + 1]);
+
+                //  texture.mipMapData.Add(mip);
+            }
 
             switch (format)
             {
@@ -73,7 +90,7 @@ namespace Smash_Forge
                     byte[] fixBC1 = DDS_Decompress.DecompressBC1(texture.data, texture.width, texture.height, true);
                     texture.data = fixBC1;
                     texture.pixelInternalFormat = PixelInternalFormat.Rgba;
-                    texture.utype = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
+                    texture.pixelFormat = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
                     break;
                 case ((int)GTX.GX2SurfaceFormat.GX2_SURFACE_FORMAT_T_BC2_UNORM):
                     texture.pixelInternalFormat = PixelInternalFormat.CompressedRgbaS3tcDxt3Ext;
@@ -101,12 +118,12 @@ namespace Smash_Forge
                     byte[] fixBC5 = DDS_Decompress.DecompressBC5(texture.data, texture.width, texture.height, true);
                     texture.data = fixBC5;
                     texture.pixelInternalFormat = PixelInternalFormat.Rgba;
-                    texture.utype = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
+                    texture.pixelFormat = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
 
                     break;
                 case ((int)GTX.GX2SurfaceFormat.GX2_SURFACE_FORMAT_TCS_R8_G8_B8_A8_UNORM):
                     texture.pixelInternalFormat = PixelInternalFormat.Rgba;
-                    texture.utype = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
+                    texture.pixelFormat = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
                     break;
             }
         }
@@ -117,78 +134,37 @@ namespace Smash_Forge
             public int width, height;
             public int display = 0;
             public PixelInternalFormat pixelInternalFormat;
-            public OpenTK.Graphics.OpenGL.PixelFormat utype;
+            public PixelFormat pixelFormat;
+            public PixelType pixelType = PixelType.UnsignedByte;
             public int mipMapCount;
-        }
-        public static int getImageSize(FTEX_Texture t)
-        {
-            switch (t.pixelInternalFormat)
-            {
-                case PixelInternalFormat.CompressedRgbaS3tcDxt1Ext:
-                case PixelInternalFormat.CompressedSrgbAlphaS3tcDxt1Ext:
-                case PixelInternalFormat.CompressedRedRgtc1:
-                case PixelInternalFormat.CompressedSignedRedRgtc1:
-                    return (t.width * t.height / 2);
-                case PixelInternalFormat.CompressedRgbaS3tcDxt3Ext:
-                case PixelInternalFormat.CompressedSrgbAlphaS3tcDxt3Ext:
-                case PixelInternalFormat.CompressedRgbaS3tcDxt5Ext:
-                case PixelInternalFormat.CompressedSrgbAlphaS3tcDxt5Ext:
-                case PixelInternalFormat.CompressedSignedRgRgtc2:
-                case PixelInternalFormat.CompressedRgRgtc2:
-                    return (t.width * t.height);
-                case PixelInternalFormat.Rgba:
-                    return t.data.Length;
-                default:
-                    return t.data.Length;
-            }
+            public List<byte[]> mipMapData = new List<byte[]>();
         }
 
         public static SFTex.Texture2D CreateTexture2D(FTEX_Texture tex, int surfaceIndex = 0)
         {
-            bool compressedFormatWithMipMaps = tex.pixelInternalFormat == PixelInternalFormat.CompressedRgbaS3tcDxt1Ext
-    || tex.pixelInternalFormat == PixelInternalFormat.CompressedRgbaS3tcDxt3Ext
-    || tex.pixelInternalFormat == PixelInternalFormat.CompressedRgbaS3tcDxt5Ext
-    || tex.pixelInternalFormat == PixelInternalFormat.CompressedRedRgtc1
-    || tex.pixelInternalFormat == PixelInternalFormat.CompressedRgRgtc2
-    || tex.pixelInternalFormat == PixelInternalFormat.CompressedSignedRgRgtc2
-    || tex.pixelInternalFormat == PixelInternalFormat.CompressedRgbaBptcUnorm
-    || tex.pixelInternalFormat == PixelInternalFormat.CompressedSrgbAlphaS3tcDxt5Ext
-    || tex.pixelInternalFormat == PixelInternalFormat.CompressedSrgbAlphaS3tcDxt3Ext;
+            bool compressedFormatWithMipMaps = SFGraphics.GLObjects.Textures.TextureFormatTools.IsCompressed(tex.pixelInternalFormat);
 
             if (compressedFormatWithMipMaps)
             {
-                //Todo. Use mip maps from BNTX
+                if (tex.mipMapData.Count > 1)
+                {
+                    // Only load the first level and generate the rest.
+                    return new SFTex.Texture2D(tex.width, tex.height, tex.data, tex.mipMapData.Count,
+                        (InternalFormat)tex.pixelInternalFormat);
+                }
+                else
+                {
+                    // Only load the first level and generate the rest.
+                    return new SFTex.Texture2D(tex.width, tex.height, tex.data, tex.mipMapData.Count,
+                        (InternalFormat)tex.pixelInternalFormat);
+                }
             }
             else
             {
-
+                // Uncompressed.
+                return new SFTex.Texture2D(tex.width, tex.height, tex.data, tex.mipMapCount,
+                    tex.pixelInternalFormat, tex.pixelFormat, tex.pixelType);
             }
-
-            SFTex.Texture2D texture = new SFTex.Texture2D(tex.width, tex.height, tex.pixelInternalFormat);
-            texture.Bind();
-            AutoGenerateMipMaps(tex);
-            tex.display = texture.Id;
-            return texture;
-        }
-
-        private static void AutoGenerateMipMaps(FTEX_Texture t)
-        {
-            // Only load the first level and generate the other mip maps.
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, t.mipMapCount);
-
-            if (t.pixelInternalFormat != PixelInternalFormat.Rgba)
-            {
-                GL.CompressedTexImage2D<byte>(TextureTarget.Texture2D, 0, (InternalFormat)t.pixelInternalFormat,
-                    t.width, t.height, 0, getImageSize(t), t.data);
-            }
-            else
-            {
-                GL.TexImage2D<byte>(TextureTarget.Texture2D, 0, t.pixelInternalFormat, t.width, t.height, 0,
-                    t.utype, PixelType.UnsignedByte, t.data);
-            }
-
-            GL.TexImage2D<byte>(TextureTarget.Texture2D, 0, t.pixelInternalFormat, t.width, t.height, 0, t.utype, PixelType.UnsignedByte, t.data);
-            GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
         }
     }
 }

--- a/Smash Forge/Filetypes/BFRES/WiiU/FTEX.cs
+++ b/Smash Forge/Filetypes/BFRES/WiiU/FTEX.cs
@@ -144,6 +144,7 @@ namespace Smash_Forge
         {
             bool compressedFormatWithMipMaps = SFGraphics.GLObjects.Textures.TextureFormatTools.IsCompressed(tex.pixelInternalFormat);
 
+            //Todo. Use mip maps from FTEX
             if (compressedFormatWithMipMaps)
             {
                 if (tex.mipMapData.Count > 1)

--- a/Smash Forge/Filetypes/Textures/DDS.cs
+++ b/Smash Forge/Filetypes/Textures/DDS.cs
@@ -389,7 +389,7 @@ namespace Smash_Forge
                 case 0x0:
                     size = 4f;
                     tex.pixelInternalFormat = PixelInternalFormat.SrgbAlpha;
-                    tex.utype = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
+                    tex.pixelFormat = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
                     break;
                 case 0x31545844:
                     size = 1 / 2f;

--- a/Smash Forge/GUI/Editors/BNTXEditor.cs
+++ b/Smash Forge/GUI/Editors/BNTXEditor.cs
@@ -248,7 +248,7 @@ namespace Smash_Forge
 
                     GL.DeleteTexture(t.texture.display);
 
-                    //Todo. Create new texture 2d object for this
+                    BNTX.glTexByName.Add(ofd.FileName, BRTI.CreateTexture2D(t.texture));
 
                     if (newTexture == null)
                         return;

--- a/Smash Forge/GUI/Editors/BNTXEditor.cs
+++ b/Smash Forge/GUI/Editors/BNTXEditor.cs
@@ -152,7 +152,7 @@ namespace Smash_Forge
             tex.width = bmp.Width;
             tex.height = bmp.Height;
             tex.pixelInternalFormat = PixelInternalFormat.Rgba;
-            tex.utype = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
+            tex.pixelFormat = OpenTK.Graphics.OpenGL.PixelFormat.Rgba;
 
             return tex;
         }
@@ -243,11 +243,12 @@ namespace Smash_Forge
                     t.texture.width = newTexture.width;
                     t.texture.pixelInternalFormat = newTexture.pixelInternalFormat;
                     t.texture.mipmaps = newTexture.mipmaps;
-                    t.texture.utype = newTexture.utype;
+                    t.texture.pixelFormat = newTexture.pixelFormat;
                     t.texture.data = newTexture.data;
 
                     GL.DeleteTexture(t.texture.display);
-                    t.texture.display = BRTI.loadImage(t.texture);
+
+                    //Todo. Create new texture 2d object for this
 
                     if (newTexture == null)
                         return;

--- a/Smash Forge/GUI/MainForm.cs
+++ b/Smash Forge/GUI/MainForm.cs
@@ -1283,8 +1283,17 @@ namespace Smash_Forge
 
                 if (magic2 == "BNTX") //SARC compressed
                 {
-                    BNTXEditor editor = new BNTXEditor(fileByteData);
+                    ModelContainer modelContainer = new ModelContainer();
+
+                    modelContainer.BNTX = new BNTX();
+                    modelContainer.BNTX.ReadBNTXFile(fileByteData);
+                    Runtime.BNTXList.Add(modelContainer.BNTX);
+                    Runtime.glTexturesNeedRefreshing = true;
+
+                    BNTXEditor editor = new BNTXEditor(modelContainer.BNTX);
                     AddDockedControl(editor);
+
+                    mvp.meshList.filesTreeView.Nodes.Add(modelContainer);
                 }
 
                 if (magic2 == "SARC") //SARC compressed
@@ -1372,12 +1381,17 @@ namespace Smash_Forge
 
             if (fileName.EndsWith(".bntx"))
             {
-                FileData f = new FileData(fileName);
+                ModelContainer modelContainer = new ModelContainer();
 
-                byte[] data = f.getSection(0, f.eof());
+                modelContainer.BNTX = new BNTX();
+                modelContainer.BNTX.ReadBNTXFile(fileName);
+                Runtime.BNTXList.Add(modelContainer.BNTX);
+                Runtime.glTexturesNeedRefreshing = true;
 
-                BNTXEditor editor = new BNTXEditor(data);
+                BNTXEditor editor = new BNTXEditor(modelContainer.BNTX);
                 AddDockedControl(editor);
+
+                mvp.meshList.filesTreeView.Nodes.Add(modelContainer);
             }
 
             if (fileName.EndsWith(".tex"))

--- a/Smash Forge/GUI/ModelViewport.cs
+++ b/Smash Forge/GUI/ModelViewport.cs
@@ -2200,7 +2200,7 @@ namespace Smash_Forge
                 {
                     m.BNTX.RefreshGlTexturesByName();
                 }
-                if (m.Bfres != null)
+                if (m.Bfres.FTEXContainer != null)
                 {
                     m.Bfres.FTEXContainer.RefreshGlTexturesByName();
                 }


### PR DESCRIPTION
This specifically fixes FTEX textures not binding and the containers being ran as null (would break switch bfres from opening) and uses the changed Texture2D constructors now. Mip maps are not implemented yet but is planned in a later PR. 

Edit: wait till i fix up bntx editor for merging. 