### PR TITLE
Rework alpha function

### DIFF
--- a/Smash Forge/Filetypes/Application/MaterialXML.cs
+++ b/Smash Forge/Filetypes/Application/MaterialXML.cs
@@ -74,10 +74,9 @@ namespace SmashForge
             AddUintAttribute(doc, "flags", mat.Flags, matNode, true);
             AddIntAttribute(doc, "srcFactor", mat.SrcFactor, matNode, false);
             AddIntAttribute(doc, "dstFactor", mat.DstFactor, matNode, false);
-            AddIntAttribute(doc, "AlphaFunc", mat.AlphaFunction, matNode, false);
-            AddIntAttribute(doc, "AlphaTest", mat.AlphaTest, matNode, false);
-            AddIntAttribute(doc, "RefAlpha", mat.RefAlpha, matNode, false);
-            AddIntAttribute(doc, "cullmode", mat.CullMode, matNode, true);
+            AddIntAttribute(doc, "alphaFunc", mat.AlphaFunc, matNode, true);
+            AddIntAttribute(doc, "alphaRef", mat.RefAlpha, matNode, false);
+            AddIntAttribute(doc, "cullMode", mat.CullMode, matNode, true);
             AddIntAttribute(doc, "zbuffoff", mat.ZBufferOffset, matNode, false);
         }
 
@@ -114,13 +113,14 @@ namespace SmashForge
                 }
                 else
                 {
-                    int count = 0;
-                    foreach (float f in mat.GetPropertyValues(materialProperty))
+                    float[] values = mat.GetPropertyValues(materialProperty);
+                    // Only print 4 values, to avoid lots of trailing zeroes.
+                    for (int count = 0, max = Math.Min(4, values.Length);;)
                     {
-                        // Only print 4 values and avoids tons of trailing 0's.
-                        if (count <= 4)
-                            paramnode.InnerText += f.ToString() + " ";
-                        count += 1;
+                        paramnode.InnerText += values[count++].ToString("G9");
+                        if (count >= max)
+                            break;
+                        paramnode.InnerText += " ";
                     }
 
                 }
@@ -252,7 +252,7 @@ namespace SmashForge
 
         private static void ReadAttributes(XmlNode materialNode, Nud.Material material)
         {
-            int value = 0;
+            int value;
             foreach (XmlAttribute attribute in materialNode.Attributes)
             {
                 switch (attribute.Name)
@@ -270,18 +270,16 @@ namespace SmashForge
                         int.TryParse(attribute.Value, out value);
                         material.DstFactor = value;
                         break;
-                    case "AlphaFunc":
-                        int.TryParse(attribute.Value, out value);
-                        material.AlphaFunction = value;
+                    case "alphaFunc":
+                        int.TryParse(attribute.Value, NumberStyles.HexNumber, null, out value);
+                        material.AlphaFunc = value;
                         break;
-                    case "AlphaTest":
-                        int.TryParse(attribute.Value, out value);
-                        material.AlphaTest = value;
-                        break;
+                    case "alphaRef":
                     case "RefAlpha":
                         int.TryParse(attribute.Value, out value);
                         material.RefAlpha = value;
                         break;
+                    case "cullMode":
                     case "cullmode":
                         int.TryParse(attribute.Value, NumberStyles.HexNumber, null, out value);
                         material.CullMode = value;
@@ -289,6 +287,16 @@ namespace SmashForge
                     case "zbuffoff":
                         int.TryParse(attribute.Value, out value);
                         material.ZBufferOffset = value;
+                        break;
+
+                    // We no longer use these, but still support for historical compatibility
+                    case "AlphaFunc":
+                        int.TryParse(attribute.Value, out value);
+                        material.AlphaFunction = value;
+                        break;
+                    case "AlphaTest":
+                        int.TryParse(attribute.Value, out value);
+                        material.AlphaTest = value;
                         break;
                 }
             }

--- a/Smash Forge/Filetypes/Application/MaterialXML.cs
+++ b/Smash Forge/Filetypes/Application/MaterialXML.cs
@@ -274,11 +274,13 @@ namespace SmashForge
                         int.TryParse(attribute.Value, NumberStyles.HexNumber, null, out value);
                         material.AlphaFunc = value;
                         break;
+                    // "RefAlpha" was the old name, still supported for historical compatibility with old XMLs.
                     case "alphaRef":
                     case "RefAlpha":
                         int.TryParse(attribute.Value, out value);
                         material.RefAlpha = value;
                         break;
+                    // "cullmode" was the old name, still supported
                     case "cullMode":
                     case "cullmode":
                         int.TryParse(attribute.Value, NumberStyles.HexNumber, null, out value);
@@ -289,7 +291,7 @@ namespace SmashForge
                         material.ZBufferOffset = value;
                         break;
 
-                    // We no longer use these, but still support for historical compatibility
+                    // No longer used, but still supported.
                     case "AlphaFunc":
                         int.TryParse(attribute.Value, out value);
                         material.AlphaFunction = value;

--- a/Smash Forge/Filetypes/Models/Nuds/Material.cs
+++ b/Smash Forge/Filetypes/Models/Nuds/Material.cs
@@ -40,8 +40,16 @@ namespace SmashForge
             public int DstFactor { get; set; }
             public int SrcFactor { get; set; }
 
-            public int AlphaTest { get; set; }
-            public int AlphaFunction { get; set; }
+            // AlphaTest and AlphaFunction are deprecated. Use AlphaFunc instead.
+            public int AlphaFunc = 0;
+            public int AlphaTest {
+                get { return AlphaFunc >> 8; }
+                set { AlphaFunc = value << 8; }
+            }
+            public int AlphaFunction {
+                get { return AlphaFunc & 0xFF; }
+                set { AlphaFunc = value & 0xFF; }
+            }
             public int RefAlpha { get; set; }
 
             public int CullMode { get; set; }

--- a/Smash Forge/Filetypes/Models/Nuds/NUD.cs
+++ b/Smash Forge/Filetypes/Models/Nuds/NUD.cs
@@ -950,8 +950,7 @@ namespace SmashForge
                 m.SrcFactor = d.ReadUShort();
                 ushort texCount = d.ReadUShort();
                 m.DstFactor = d.ReadUShort();
-                m.AlphaTest = d.ReadByte();
-                m.AlphaFunction = d.ReadByte();
+                m.AlphaFunc = d.ReadUShort();
                 m.RefAlpha = d.ReadUShort();
                 m.CullMode = d.ReadUShort();
                 d.Skip(4); // unknown
@@ -1559,9 +1558,7 @@ namespace SmashForge
                 d.WriteShort(mat.SrcFactor);
                 d.WriteShort(mat.textures.Count);
                 d.WriteShort(mat.DstFactor);
-                d.WriteByte(mat.AlphaTest);
-                d.WriteByte(mat.AlphaFunction);
-
+                d.WriteShort(mat.AlphaFunc);
                 d.WriteShort(mat.RefAlpha);
                 d.WriteShort(mat.CullMode);
                 d.WriteInt(0); // unknown

--- a/Smash Forge/Filetypes/Models/Nuds/NudEnums.cs
+++ b/Smash Forge/Filetypes/Models/Nuds/NudEnums.cs
@@ -5,12 +5,6 @@ namespace SmashForge.Filetypes.Models.Nuds
 {
     public static class NudEnums
     {
-        public enum AlphaTest
-        {
-            Enabled = 0x02,
-            Disabled = 0x00
-        }
-
         public static readonly Dictionary<int, BlendingFactor> srcFactorByMatValue = new Dictionary<int, BlendingFactor>()
         {
             { 0x00, BlendingFactor.One },
@@ -59,9 +53,25 @@ namespace SmashForge.Filetypes.Models.Nuds
 
         public static readonly Dictionary<int, AlphaFunction> alphaFunctionByMatValue = new Dictionary<int, AlphaFunction>()
         {
-            { 0x0, AlphaFunction.Never },
-            { 0x4, AlphaFunction.Gequal },
-            { 0x6, AlphaFunction.Gequal },
+            // OpenGL (used in NDP3 games like Smash)
+            { 0x200, AlphaFunction.Never },
+            { 0x201, AlphaFunction.Less },
+            { 0x202, AlphaFunction.Equal },
+            { 0x203, AlphaFunction.Lequal },
+            { 0x204, AlphaFunction.Greater },
+            { 0x205, AlphaFunction.Notequal },
+            { 0x206, AlphaFunction.Gequal },
+            { 0x207, AlphaFunction.Always },
+
+            // Direct3D (used in NDWD games like Pokken)
+            { 1, AlphaFunction.Never },
+            { 2, AlphaFunction.Less },
+            { 3, AlphaFunction.Equal },
+            { 4, AlphaFunction.Lequal },
+            { 5, AlphaFunction.Greater },
+            { 6, AlphaFunction.Notequal },
+            { 7, AlphaFunction.Gequal },
+            { 8, AlphaFunction.Always }
         };
 
         public static readonly Dictionary<int, TextureWrapMode> wrapModeByMatValue = new Dictionary<int, TextureWrapMode>()

--- a/Smash Forge/Filetypes/Models/Nuds/NudRenderMesh.cs
+++ b/Smash Forge/Filetypes/Models/Nuds/NudRenderMesh.cs
@@ -78,14 +78,12 @@ namespace SmashForge
 
         private void SetAlphaTesting(Nud.Material material)
         {
-
-            bool enabled = (material.AlphaTest == (int)NudEnums.AlphaTest.Enabled);
-
             AlphaFunction alphaFunc = AlphaFunction.Always;
-            if (NudEnums.alphaFunctionByMatValue.ContainsKey(material.AlphaFunction))
-                alphaFunc = NudEnums.alphaFunctionByMatValue[material.AlphaFunction];
-
             float refAlpha = material.RefAlpha / 255.0f;
+
+            bool enabled = NudEnums.alphaFunctionByMatValue.ContainsKey(material.AlphaFunc);
+            if (enabled)
+                alphaFunc = NudEnums.alphaFunctionByMatValue[material.AlphaFunc];
 
             renderSettings.alphaTestSettings = new AlphaTestSettings(enabled, alphaFunc, refAlpha);
         }

--- a/Smash Forge/GUI/Editors/NUDMaterialEditor.Designer.cs
+++ b/Smash Forge/GUI/Editors/NUDMaterialEditor.Designer.cs
@@ -99,7 +99,6 @@
             this.alphaTestButton = new System.Windows.Forms.Button();
             this.alphaTestPanel = new System.Windows.Forms.Panel();
             this.alphaTestFlowLayout = new System.Windows.Forms.FlowLayoutPanel();
-            this.alphaTestCB = new System.Windows.Forms.CheckBox();
             this.alphaFuncRefPanel = new System.Windows.Forms.Panel();
             this.alphaTestTableLayout = new System.Windows.Forms.TableLayoutPanel();
             this.refAlphaTB = new System.Windows.Forms.TextBox();
@@ -922,7 +921,6 @@
             // alphaTestFlowLayout
             // 
             this.alphaTestFlowLayout.AutoSize = true;
-            this.alphaTestFlowLayout.Controls.Add(this.alphaTestCB);
             this.alphaTestFlowLayout.Controls.Add(this.alphaFuncRefPanel);
             this.alphaTestFlowLayout.Dock = System.Windows.Forms.DockStyle.Fill;
             this.alphaTestFlowLayout.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
@@ -932,17 +930,6 @@
             this.alphaTestFlowLayout.TabIndex = 24;
             this.alphaTestFlowLayout.WrapContents = false;
             this.alphaTestFlowLayout.Resize += new System.EventHandler(this.flowLayout_Resize);
-            // 
-            // alphaTestCB
-            // 
-            this.alphaTestCB.AutoSize = true;
-            this.alphaTestCB.Location = new System.Drawing.Point(3, 3);
-            this.alphaTestCB.Name = "alphaTestCB";
-            this.alphaTestCB.Size = new System.Drawing.Size(91, 17);
-            this.alphaTestCB.TabIndex = 25;
-            this.alphaTestCB.Text = "Alpha Testing";
-            this.alphaTestCB.UseVisualStyleBackColor = true;
-            this.alphaTestCB.CheckedChanged += new System.EventHandler(this.alphaTestCB_CheckedChanged);
             // 
             // alphaFuncRefPanel
             // 
@@ -1428,7 +1415,6 @@
         private System.Windows.Forms.Label propertyNameLabel;
         private System.Windows.Forms.Button deleteMatPropertyButton;
         private System.Windows.Forms.FlowLayoutPanel alphaTestFlowLayout;
-        private System.Windows.Forms.CheckBox alphaTestCB;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.TextBox refAlphaTB;
         private System.Windows.Forms.FlowLayoutPanel generalFlowLayout;

--- a/Smash Forge/GUI/Editors/NUDMaterialEditor.cs
+++ b/Smash Forge/GUI/Editors/NUDMaterialEditor.cs
@@ -286,12 +286,6 @@ namespace SmashForge
         {
             shadowCB.Checked = mat.HasShadow;
             GlowCB.Checked = mat.Glow;
-
-            // TODO: Remove alphaTestCB as it's useless. Making it invisible for now.
-            alphaTestCB.Checked = true;
-            alphaTestCB.Visible = false;
-            // Enable/disable extra controls.
-            alphaTestCB_CheckedChanged(null, null);
         }
 
         private void InitializeTextBoxes(Nud.Material mat)
@@ -1039,21 +1033,6 @@ namespace SmashForge
         private void param4TrackBar_Leave(object sender, EventArgs e)
         {
             enableParam4SliderUpdates = true;
-        }
-
-        private void alphaTestCB_CheckedChanged(object sender, EventArgs e)
-        {
-            /*if (alphaTestCB.Checked)
-                currentMaterialList[currentMatIndex].AlphaTest = (int)NudEnums.AlphaTest.Enabled;
-            else
-                currentMaterialList[currentMatIndex].AlphaTest = (int)NudEnums.AlphaTest.Disabled;
-
-            // Only enable extra settings when alpha testing is enabled.
-            alphaFuncRefPanel.Visible = alphaTestCB.Checked;
-            */
-
-            // Force all flow layouts to rescale children.
-            GuiTools.ScaleControlsHorizontallyToLayoutWidth(generalFlowLayout);
         }
 
         private void flagsButton_Click(object sender, EventArgs e)

--- a/Smash Forge/GUI/Editors/NUDMaterialEditor.cs
+++ b/Smash Forge/GUI/Editors/NUDMaterialEditor.cs
@@ -41,9 +41,24 @@ namespace SmashForge
 
         public static Dictionary<int, string> alphaFuncByMatValue = new Dictionary<int, string>()
         {
-            { 0x00, "Never"},
-            { 0x04, "Gequal Ref Alpha"},
-            { 0x06, "Gequal Ref Alpha + ???"}
+            { 0x000, "None (Always)" },
+            { 0x200, "Never" },
+            { 0x201, "Less (<)" },
+            { 0x202, "Equal (==)" },
+            { 0x203, "Less or equal (<=)" },
+            { 0x204, "Greater (>)" },
+            { 0x205, "Not equal (!=)" },
+            { 0x206, "Greater or equal (>=)" },
+            { 0x207, "Always" },
+            // Direct3D
+            { 1, "(Pokkén) Never" },
+            { 2, "(Pokkén) Less (<)" },
+            { 3, "(Pokkén) Equal (==)" },
+            { 4, "(Pokkén) Less or equal (<=)" },
+            { 5, "(Pokkén) Greater (>)" },
+            { 6, "(Pokkén) Not equal (!=)" },
+            { 7, "(Pokkén) Greater or equal (>=)" },
+            { 8, "(Pokkén) Always" }
         };
 
         public static Dictionary<int, string> mapModeByMatValue = new Dictionary<int, string>()
@@ -263,7 +278,7 @@ namespace SmashForge
 
         private void InitializeComboBoxes(Nud.Material mat)
         {
-            alphaFuncComboBox.SelectedItem = alphaFuncByMatValue[mat.AlphaFunction];
+            alphaFuncComboBox.SelectedItem = alphaFuncByMatValue[mat.AlphaFunc];
             cullModeComboBox.SelectedItem = cullModeByMatValue[mat.CullMode];
         }
 
@@ -272,7 +287,9 @@ namespace SmashForge
             shadowCB.Checked = mat.HasShadow;
             GlowCB.Checked = mat.Glow;
 
-            alphaTestCB.Checked = mat.AlphaTest == (int)NudEnums.AlphaTest.Enabled;
+            // TODO: Remove alphaTestCB as it's useless. Making it invisible for now.
+            alphaTestCB.Checked = true;
+            alphaTestCB.Visible = false;
             // Enable/disable extra controls.
             alphaTestCB_CheckedChanged(null, null);
         }
@@ -377,7 +394,7 @@ namespace SmashForge
             {
                 if (alphaFuncByMatValue[i].Equals(alphaFuncComboBox.SelectedItem))
                 {
-                    currentMaterialList[currentMatIndex].AlphaFunction = i;
+                    currentMaterialList[currentMatIndex].AlphaFunc = i;
                     break;
                 }
             }
@@ -1026,13 +1043,14 @@ namespace SmashForge
 
         private void alphaTestCB_CheckedChanged(object sender, EventArgs e)
         {
-            if (alphaTestCB.Checked)
+            /*if (alphaTestCB.Checked)
                 currentMaterialList[currentMatIndex].AlphaTest = (int)NudEnums.AlphaTest.Enabled;
             else
                 currentMaterialList[currentMatIndex].AlphaTest = (int)NudEnums.AlphaTest.Disabled;
 
             // Only enable extra settings when alpha testing is enabled.
             alphaFuncRefPanel.Visible = alphaTestCB.Checked;
+            */
 
             // Force all flow layouts to rescale children.
             GuiTools.ScaleControlsHorizontallyToLayoutWidth(generalFlowLayout);


### PR DESCRIPTION
I have reworked the alpha function material value. Forge has handled it as two separate values, but in fact it's only one. I've updated the IO code accordingly, as well as the material editor and material XML.
- Materials have a new value called `AlphaFunc`. The two previous values, `AlphaTest` and `AlphaFunction`, are still supported via properties, but should not be used.
- All alpha functions should now render correctly, including Pokken.
- Material editor:
  - Always show the alpha function dropdown. The alpha test checkbox has been removed.
  - Added the alpha function values used in Pokken.
- Material XML:
  - Export the value `alphaFunc`, instead of `AlphaFunc` and `AlphaTest`.
  - Renamed `RefAlpha` and `cullmode`, to `alphaRef` and `cullMode`, respectively, for consistency with other value names.
  - Previous keys are still supported, for backwards compatibility with existing material XML files.