### PR TITLE
Add NUD float UV support

### DIFF
--- a/Smash Forge/Filetypes/Models/Nuds/Material.cs
+++ b/Smash Forge/Filetypes/Models/Nuds/Material.cs
@@ -44,11 +44,11 @@ namespace SmashForge
             public int AlphaFunc = 0;
             public int AlphaTest {
                 get { return AlphaFunc >> 8; }
-                set { AlphaFunc = value << 8; }
+                set { AlphaFunc = (value << 8) | (AlphaFunc & 0xFF); }
             }
             public int AlphaFunction {
                 get { return AlphaFunc & 0xFF; }
-                set { AlphaFunc = value & 0xFF; }
+                set { AlphaFunc = (AlphaFunc & 0xFF00) | (value & 0xFF); }
             }
             public int RefAlpha { get; set; }
 

--- a/Smash Forge/Filetypes/Models/Nuds/Polygon.cs
+++ b/Smash Forge/Filetypes/Models/Nuds/Polygon.cs
@@ -13,7 +13,7 @@ namespace SmashForge
         {
             public enum BoneTypes
             {
-                NoBones =  0x00,
+                NoBones = 0x00,
                 Float = 0x10,
                 HalfFloat = 0x20,
                 Byte = 0x40
@@ -26,6 +26,12 @@ namespace SmashForge
                 NormalsTanBiTanFloat = 0x3,
                 NormalsHalfFloat = 0x6,
                 NormalsTanBiTanHalfFloat = 0x7
+            }
+
+            public enum UVTypes
+            {
+                HalfFloat = 0,
+                Float = 1 // Only seen in Wangan Midnight
             }
 
             public enum VertexColorTypes
@@ -67,10 +73,11 @@ namespace SmashForge
 
             public int uvCount = 1;
             public int colorType = (int)VertexColorTypes.Byte;
-            // uvCount is upper nybble, normalType is lower nybble
+            public int uvType = (int)UVTypes.HalfFloat;
+            // uvCount is upper nybble, colorType and uvType is lower nybble
             public int UVSize {
-                get { return (uvCount << 4) | (colorType & 0xF); }
-                set { uvCount = value >> 4; colorType = value & 0xF; }
+                get { return (uvCount << 4) | (colorType & 0xE) | uvType; }
+                set { uvCount = value >> 4; colorType = value & 0xE; uvType = value & 1;}
             }
 
             public int strip = (int)PrimitiveTypes.Triangles;


### PR DESCRIPTION
I've added support for a NUD vertex format flag, wherein UV data is stored as floats rather than half-floats. It's used in the Wangan Midnight games. Thanks to @wood5578 for ongoing collaboration; bringing this particular issue to my attention, providing files, and testing changes.
- Added a new polygon attribute, `uvType`, and a new enum, `UVTypes`
- Updated the NUD IO code accordingly
  - It also now uses more abstractions, such as the new attributes and enums, rather than magic numbers.
- Fixed a potential issue with the deprecated material attributes, `AlphaTest` and `AlphaFunction`, not matching their prior implementation, which could have resulted in erroneous behavior when importing old XMLs.