### PR TITLE
New additions to PolygonFormatEditor menu

### DIFF
--- a/Smash Forge/Filetypes/Models/Nuds/Polygon.cs
+++ b/Smash Forge/Filetypes/Models/Nuds/Polygon.cs
@@ -335,11 +335,10 @@ namespace SmashForge
                 mat.textures.Add(MatTexture.GetDefault());
             }
 
-            public List<int> GetRenderingVertexIndices()
+            public List<int> GetTriangles()
             {
                 if (strip == (int)PrimitiveTypes.Triangles)
                 {
-                    displayFaceSize = vertexIndices.Count;
                     return vertexIndices;
                 }
                 else if (strip == (int)PrimitiveTypes.TriangleStrip)
@@ -384,13 +383,50 @@ namespace SmashForge
                         }
                     } while (p < this.vertexIndices.Count);
 
-                    displayFaceSize = vertexIndices.Count;
                     return vertexIndices;
                 }
                 else
                 {
                     throw new NotImplementedException("Face type not supported: " + strip);
                 }
+            }
+
+            public List<int> GetTriangleStrip()
+            {
+                if (strip == (int)PrimitiveTypes.TriangleStrip)
+                {
+                    return vertexIndices;
+                }
+                else if (strip == (int)PrimitiveTypes.Triangles)
+                {
+                    // TODO: Come up with a proper algorithm.
+                    // This is the simplest possible form, as it merely puts
+                    // the triangles directly into the strip format.
+                    List<int> vertexIndices = new List<int>();
+
+                    for (int p = 0;;)
+                    {
+                        vertexIndices.Add(this.vertexIndices[p++]);
+                        vertexIndices.Add(this.vertexIndices[p++]);
+                        vertexIndices.Add(this.vertexIndices[p++]);
+                        if (p < this.vertexIndices.Count)
+                            vertexIndices.Add(0xFFFF);
+                        else
+                            break;
+                    }
+                    return vertexIndices;
+                }
+                else
+                {
+                    throw new NotImplementedException("Face type not supported: " + strip);
+                }
+            }
+
+            public List<int> GetRenderingVertexIndices()
+            {
+                List<int> vertexIndices = GetTriangles();
+                displayFaceSize = vertexIndices.Count;
+                return vertexIndices;
             }
         }
     }

--- a/Smash Forge/Filetypes/Models/Nuds/Polygon.cs
+++ b/Smash Forge/Filetypes/Models/Nuds/Polygon.cs
@@ -404,15 +404,13 @@ namespace SmashForge
                     // the triangles directly into the strip format.
                     List<int> vertexIndices = new List<int>();
 
-                    for (int p = 0;;)
+                    for (int p = 0; p < this.vertexIndices.Count; p += 3)
                     {
-                        vertexIndices.Add(this.vertexIndices[p++]);
-                        vertexIndices.Add(this.vertexIndices[p++]);
-                        vertexIndices.Add(this.vertexIndices[p++]);
-                        if (p < this.vertexIndices.Count)
+                        if (p > 0)
                             vertexIndices.Add(0xFFFF);
-                        else
-                            break;
+                        vertexIndices.Add(this.vertexIndices[p]);
+                        vertexIndices.Add(this.vertexIndices[p+1]);
+                        vertexIndices.Add(this.vertexIndices[p+2]);
                     }
                     return vertexIndices;
                 }

--- a/Smash Forge/GUI/Menus/PolygonFormatEditor.Designer.cs
+++ b/Smash Forge/GUI/Menus/PolygonFormatEditor.Designer.cs
@@ -33,9 +33,14 @@
             this.normalTypeLabel = new System.Windows.Forms.Label();
             this.weightTypeComboBox = new System.Windows.Forms.ComboBox();
             this.normalTypeComboBox = new System.Windows.Forms.ComboBox();
-            this.vertexColorCB = new System.Windows.Forms.CheckBox();
+            this.uvTypeLabel = new System.Windows.Forms.Label();
+            this.colorTypeLabel = new System.Windows.Forms.Label();
+            this.uvTypeComboBox = new System.Windows.Forms.ComboBox();
+            this.colorTypeComboBox = new System.Windows.Forms.ComboBox();
             this.uvCountLabel = new System.Windows.Forms.Label();
             this.uvCountUpDown = new System.Windows.Forms.NumericUpDown();
+            this.faceTypeLabel = new System.Windows.Forms.Label();
+            this.faceTypeComboBox = new System.Windows.Forms.ComboBox();
             this.applyButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
@@ -76,28 +81,53 @@
             this.normalTypeComboBox.Size = new System.Drawing.Size(141, 33);
             this.normalTypeComboBox.TabIndex = 1;
             // 
-            // vertexColorCB
+            // uvTypeLabel
             // 
-            this.vertexColorCB.AutoSize = true;
-            this.vertexColorCB.Location = new System.Drawing.Point(6, 59);
-            this.vertexColorCB.Margin = new System.Windows.Forms.Padding(2);
-            this.vertexColorCB.Name = "vertexColorCB";
-            this.vertexColorCB.Size = new System.Drawing.Size(110, 17);
-            this.vertexColorCB.Text = "Has Vertex Color";
-            this.vertexColorCB.UseVisualStyleBackColor = true;
-            this.vertexColorCB.TabIndex = 2;
+            this.uvTypeLabel.AutoSize = true;
+            this.uvTypeLabel.Location = new System.Drawing.Point(6, 59);
+            this.uvTypeLabel.Name = "uvTypeLabel";
+            this.uvTypeLabel.Size = new System.Drawing.Size(141, 25);
+            this.uvTypeLabel.Text = "UV Type";
+            // 
+            // colorTypeLabel
+            // 
+            this.colorTypeLabel.AutoSize = true;
+            this.colorTypeLabel.Location = new System.Drawing.Point(153, 59);
+            this.colorTypeLabel.Name = "colorTypeLabel";
+            this.colorTypeLabel.Size = new System.Drawing.Size(141, 25);
+            this.colorTypeLabel.Text = "Vertex Color Type";
+            // 
+            // uvTypeComboBox
+            // 
+            this.uvTypeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.uvTypeComboBox.FormattingEnabled = true;
+            this.uvTypeComboBox.Location = new System.Drawing.Point(6, 79);
+            this.uvTypeComboBox.Margin = new System.Windows.Forms.Padding(6);
+            this.uvTypeComboBox.Name = "uvTypeComboBox";
+            this.uvTypeComboBox.Size = new System.Drawing.Size(141, 33);
+            this.uvTypeComboBox.TabIndex = 2;
+            // 
+            // colorTypeComboBox
+            // 
+            this.colorTypeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.colorTypeComboBox.FormattingEnabled = true;
+            this.colorTypeComboBox.Location = new System.Drawing.Point(153, 79);
+            this.colorTypeComboBox.Margin = new System.Windows.Forms.Padding(6);
+            this.colorTypeComboBox.Name = "colorTypeComboBox";
+            this.colorTypeComboBox.Size = new System.Drawing.Size(141, 33);
+            this.colorTypeComboBox.TabIndex = 3;
             // 
             // uvCountLabel
             // 
             this.uvCountLabel.AutoSize = true;
-            this.uvCountLabel.Location = new System.Drawing.Point(153, 61);
+            this.uvCountLabel.Location = new System.Drawing.Point(6, 114);
             this.uvCountLabel.Name = "uvCountLabel";
             this.uvCountLabel.Size = new System.Drawing.Size(70, 25);
             this.uvCountLabel.Text = "UV channels: ";
             // 
             // uvCountUpDown
             // 
-            this.uvCountUpDown.Location = new System.Drawing.Point(235, 59);
+            this.uvCountUpDown.Location = new System.Drawing.Point(88, 112);
             this.uvCountUpDown.Margin = new System.Windows.Forms.Padding(2);
             this.uvCountUpDown.DecimalPlaces = 0;
             this.uvCountUpDown.Minimum = 0x0;
@@ -105,30 +135,53 @@
             this.uvCountUpDown.Value = 0;
             this.uvCountUpDown.Name = "uvCountUpDown";
             this.uvCountUpDown.Size = new System.Drawing.Size(40, 17);
-            this.uvCountUpDown.TabIndex = 3;
+            this.uvCountUpDown.TabIndex = 4;
+            // 
+            // faceTypeLabel
+            // 
+            this.faceTypeLabel.AutoSize = true;
+            this.faceTypeLabel.Location = new System.Drawing.Point(153, 112);
+            this.faceTypeLabel.Name = "faceTypeLabel";
+            this.faceTypeLabel.Size = new System.Drawing.Size(141, 25);
+            this.faceTypeLabel.Text = "Face Type";
+            // 
+            // faceTypeComboBox
+            // 
+            this.faceTypeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.faceTypeComboBox.FormattingEnabled = true;
+            this.faceTypeComboBox.Location = new System.Drawing.Point(153, 132);
+            this.faceTypeComboBox.Margin = new System.Windows.Forms.Padding(6);
+            this.faceTypeComboBox.Name = "faceTypeComboBox";
+            this.faceTypeComboBox.Size = new System.Drawing.Size(141, 33);
+            this.faceTypeComboBox.TabIndex = 5;
             // 
             // applyButton
             // 
-            this.applyButton.Location = new System.Drawing.Point(100, 86);
+            this.applyButton.Location = new System.Drawing.Point(100, 165);
             this.applyButton.Name = "applyButton";
             this.applyButton.Size = new System.Drawing.Size(100, 23);
             this.applyButton.Text = "Apply";
             this.applyButton.UseVisualStyleBackColor = true;
-            this.applyButton.TabIndex = 4;
+            this.applyButton.TabIndex = 6;
             this.applyButton.Click += new System.EventHandler(this.applyButton_Click);
             // 
             // PolygonFormatEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(300, 120);
+            this.ClientSize = new System.Drawing.Size(300, 200);
             this.Controls.Add(this.weightTypeLabel);
             this.Controls.Add(this.normalTypeLabel);
             this.Controls.Add(this.weightTypeComboBox);
             this.Controls.Add(this.normalTypeComboBox);
-            this.Controls.Add(this.vertexColorCB);
+            this.Controls.Add(this.uvTypeLabel);
+            this.Controls.Add(this.colorTypeLabel);
+            this.Controls.Add(this.uvTypeComboBox);
+            this.Controls.Add(this.colorTypeComboBox);
             this.Controls.Add(this.uvCountLabel);
             this.Controls.Add(this.uvCountUpDown);
+            this.Controls.Add(this.faceTypeLabel);
+            this.Controls.Add(this.faceTypeComboBox);
             this.Controls.Add(this.applyButton);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "PolygonFormatEditor";
@@ -144,9 +197,14 @@
         private System.Windows.Forms.Label normalTypeLabel;
         private System.Windows.Forms.ComboBox weightTypeComboBox;
         private System.Windows.Forms.ComboBox normalTypeComboBox;
-        private System.Windows.Forms.CheckBox vertexColorCB;
+        private System.Windows.Forms.Label uvTypeLabel;
+        private System.Windows.Forms.Label colorTypeLabel;
+        private System.Windows.Forms.ComboBox uvTypeComboBox;
+        private System.Windows.Forms.ComboBox colorTypeComboBox;
         private System.Windows.Forms.Label uvCountLabel;
         private System.Windows.Forms.NumericUpDown uvCountUpDown;
+        private System.Windows.Forms.Label faceTypeLabel;
+        private System.Windows.Forms.ComboBox faceTypeComboBox;
         private System.Windows.Forms.Button applyButton;
     }
 }

--- a/Smash Forge/GUI/Menus/PolygonFormatEditor.cs
+++ b/Smash Forge/GUI/Menus/PolygonFormatEditor.cs
@@ -10,17 +10,33 @@ namespace SmashForge
         private Dictionary<string, int> WeightTypes = new Dictionary<string, int>()
         {
             { "None", (int)Nud.Polygon.BoneTypes.NoBones},
-            { "Float", (int)Nud.Polygon.BoneTypes.Float},
+            { "Byte", (int)Nud.Polygon.BoneTypes.Byte},
             { "Half Float", (int)Nud.Polygon.BoneTypes.HalfFloat},
-            { "Byte", (int)Nud.Polygon.BoneTypes.Byte}
+            { "Float", (int)Nud.Polygon.BoneTypes.Float}
         };
         private Dictionary<string, int> NormalTypes = new Dictionary<string, int>()
         {
             { "No Normals", (int)Nud.Polygon.VertexTypes.NoNormals},
-            { "Normals (Float)", (int)Nud.Polygon.VertexTypes.NormalsFloat},
-            { "Normals, Tan, Bi-Tan (Float)", (int)Nud.Polygon.VertexTypes.NormalsTanBiTanFloat},
             { "Normals (Half Float)", (int)Nud.Polygon.VertexTypes.NormalsHalfFloat},
-            { "Normals, Tan, Bi-Tan (Half Float)", (int)Nud.Polygon.VertexTypes.NormalsTanBiTanHalfFloat}
+            { "Normals, Tan, Bi-Tan (Half Float)", (int)Nud.Polygon.VertexTypes.NormalsTanBiTanHalfFloat},
+            { "Normals (Float)", (int)Nud.Polygon.VertexTypes.NormalsFloat},
+            { "Normals, Tan, Bi-Tan (Float)", (int)Nud.Polygon.VertexTypes.NormalsTanBiTanFloat}
+        };
+        private Dictionary<string, int> ColorTypes = new Dictionary<string, int>()
+        {
+            { "None", (int)Nud.Polygon.VertexColorTypes.None},
+            { "Byte", (int)Nud.Polygon.VertexColorTypes.Byte},
+            { "Half Float", (int)Nud.Polygon.VertexColorTypes.HalfFloat}
+        };
+        private Dictionary<string, int> UVTypes = new Dictionary<string, int>()
+        {
+            { "Half Float", (int)Nud.Polygon.UVTypes.HalfFloat},
+            { "Float", (int)Nud.Polygon.UVTypes.Float}
+        };
+        private Dictionary<string, int> FaceTypes = new Dictionary<string, int>()
+        {
+            { "Triangles", (int)Nud.Polygon.PrimitiveTypes.Triangles},
+            { "Triangle Strips", (int)Nud.Polygon.PrimitiveTypes.TriangleStrip}
         };
         private PolygonFormatEditor()
         {
@@ -28,17 +44,48 @@ namespace SmashForge
 
             weightTypeComboBox.BeginUpdate();
             normalTypeComboBox.BeginUpdate();
+            colorTypeComboBox.BeginUpdate();
+            uvTypeComboBox.BeginUpdate();
+            faceTypeComboBox.BeginUpdate();
+
             weightTypeComboBox.Items.Clear();
             normalTypeComboBox.Items.Clear();
+            colorTypeComboBox.Items.Clear();
+            uvTypeComboBox.Items.Clear();
+            faceTypeComboBox.Items.Clear();
+
             weightTypeComboBox.Items.AddRange(WeightTypes.Keys.ToArray());
             normalTypeComboBox.Items.AddRange(NormalTypes.Keys.ToArray());
+            colorTypeComboBox.Items.AddRange(ColorTypes.Keys.ToArray());
+            uvTypeComboBox.Items.AddRange(UVTypes.Keys.ToArray());
+            faceTypeComboBox.Items.AddRange(FaceTypes.Keys.ToArray());
+
             weightTypeComboBox.SelectedIndex = 0;
             normalTypeComboBox.SelectedIndex = 0;
+            colorTypeComboBox.SelectedIndex = 0;
+            uvTypeComboBox.SelectedIndex = 0;
+            faceTypeComboBox.SelectedIndex = 0;
+
             weightTypeComboBox.EndUpdate();
             normalTypeComboBox.EndUpdate();
+            colorTypeComboBox.EndUpdate();
+            uvTypeComboBox.EndUpdate();
+            faceTypeComboBox.EndUpdate();
 
             uvCountUpDown.Value = 0;
-            vertexColorCB.Checked = true;
+        }
+
+        private static int SetComboBox(System.Windows.Forms.ComboBox comboBox, Dictionary<string, int> types, int value)
+        {
+            foreach (string key in types.Keys)
+            {
+                if (value == types[key])
+                {
+                    comboBox.SelectedIndex = comboBox.FindStringExact(key);
+                    break;
+                }
+            }
+            return comboBox.SelectedIndex;
         }
 
         private Nud.Polygon poly;
@@ -46,104 +93,78 @@ namespace SmashForge
         {
             this.poly = poly;
 
-            int weightType = poly.vertSize & 0xF0;
-            int normalType = poly.vertSize & 0x0F;
-            foreach (string key in WeightTypes.Keys)
-            {
-                if (weightType == WeightTypes[key])
-                {
-                    weightTypeComboBox.SelectedIndex = weightTypeComboBox.FindStringExact(key);
-                    break;
-                }
-            }
-            foreach (string key in NormalTypes.Keys)
-            {
-                if (normalType == NormalTypes[key])
-                {
-                    normalTypeComboBox.SelectedIndex = normalTypeComboBox.FindStringExact(key);
-                    break;
-                }
-            }
+            SetComboBox(weightTypeComboBox, WeightTypes, poly.boneType);
+            SetComboBox(normalTypeComboBox, NormalTypes, poly.normalType);
+            SetComboBox(colorTypeComboBox, ColorTypes, poly.colorType);
+            SetComboBox(uvTypeComboBox, UVTypes, poly.uvType);
+            SetComboBox(faceTypeComboBox, FaceTypes, poly.strip);
 
-            int uvCount = poly.UVSize >> 4;
-            int colorType = poly.UVSize & 0x0F;
-            uvCountUpDown.Value = uvCount;
-            vertexColorCB.Checked = colorType != 0;
+            uvCountUpDown.Value = poly.uvCount;
         }
 
         private void applyButton_Click(object sender, EventArgs e)
         {
             int weightType = WeightTypes[(string)weightTypeComboBox.SelectedItem];
             int normalType = NormalTypes[(string)normalTypeComboBox.SelectedItem];
-            poly.vertSize = weightType | normalType;
+            int colorType = ColorTypes[(string)colorTypeComboBox.SelectedItem];
+            int uvType = UVTypes[(string)uvTypeComboBox.SelectedItem];
+            int uvCount = (int)uvCountUpDown.Value;
+            int faceType = FaceTypes[(string)faceTypeComboBox.SelectedItem];
             foreach (Nud.Vertex v in poly.vertices)
             {
-                if (weightType == (int)Nud.Polygon.BoneTypes.Float)
+                if (weightType == (int)Nud.Polygon.BoneTypes.HalfFloat)
                 {
-                    for (int i = 0; i < v.boneIds.Count; ++i)
-                        v.boneIds[i] = (int)v.boneIds[i];
-                    for (int i = 0; i < v.boneWeights.Count; ++i)
-                        v.boneWeights[i] = (float)v.boneWeights[i];
-                }
-                else if (weightType == (int)Nud.Polygon.BoneTypes.HalfFloat)
-                {
-                    for (int i = 0; i < v.boneIds.Count; ++i)
+                    for (int i = 0; i < v.boneIds.Count; i++)
                         v.boneIds[i] = (int)(short)v.boneIds[i];
-                    for (int i = 0; i < v.boneWeights.Count; ++i)
-                        v.boneWeights[i] = (float)v.boneWeights[i];
+                    for (int i = 0; i < v.boneWeights.Count; i++)
+                        v.boneWeights[i] = FileData.ToFloat(FileData.FromFloat(v.boneWeights[i]));
                 }
                 else if (weightType == (int)Nud.Polygon.BoneTypes.Byte)
                 {
-                    for (int i = 0; i < v.boneIds.Count; ++i)
+                    for (int i = 0; i < v.boneIds.Count; i++)
                         v.boneIds[i] = (int)(byte)v.boneIds[i];
-                    for (int i = 0; i < v.boneWeights.Count; ++i)
+                    for (int i = 0; i < v.boneWeights.Count; i++)
                         v.boneWeights[i] = ((float)((byte)(v.boneWeights[i] * 255))) / 255;
                 }
-            }
 
-            int uvCount = poly.UVSize >> 4;
-            int colorType = poly.UVSize & 0x0F;
-
-            while (uvCountUpDown.Value > uvCount)
-            {
-                foreach (Nud.Vertex v in poly.vertices)
+                while (v.uv.Count < uvCount)
                 {
-                    if (uvCount > 0)
+                    if (v.uv.Count > 0)
                         v.uv.Add(new OpenTK.Vector2(v.uv[0].X, v.uv[0].Y));
                     else
                         v.uv.Add(new OpenTK.Vector2(0, 0));
                 }
-                ++uvCount;
-            }
-            while (uvCountUpDown.Value < uvCount)
-            {
-                foreach (Nud.Vertex v in poly.vertices)
+                while (v.uv.Count > uvCount)
                 {
-                    v.uv.RemoveAt(uvCount - 1);
+                    v.uv.RemoveAt(v.uv.Count - 1);
                 }
-                --uvCount;
+
+                if (uvType == (int)Nud.Polygon.UVTypes.HalfFloat)
+                {
+                    for (int i = 0; i < v.uv.Count; i++)
+                        v.uv[i] = new OpenTK.Vector2(FileData.ToFloat(FileData.FromFloat(v.uv[i].X)), FileData.ToFloat(FileData.FromFloat(v.uv[i].Y)));
+                }
+
+                if (colorType == (int)Nud.Polygon.VertexColorTypes.None)
+                {
+                    v.color = new OpenTK.Vector4(127, 127, 127, 127);
+                }
+            }
+            if (faceType == (int)Nud.Polygon.PrimitiveTypes.Triangles)
+            {
+                poly.vertexIndices = poly.GetTriangles();
+            }
+            else if (faceType == (int)Nud.Polygon.PrimitiveTypes.TriangleStrip)
+            {
+                poly.vertexIndices = poly.GetTriangleStrip();
             }
 
-            if (vertexColorCB.Checked)
-            {
-                if (colorType == 0x0)
-                {
-                    colorType = 0x2;
-                    foreach (Nud.Vertex v in poly.vertices)
-                        v.color = new OpenTK.Vector4(127, 127, 127, 127);
-                }
-            }
-            else
-            {
-                if (colorType != 0x0)
-                {
-                    colorType = 0x0;
-                    foreach (Nud.Vertex v in poly.vertices)
-                        v.color = new OpenTK.Vector4(127, 127, 127, 127);
-                }
-            }
-
-            poly.UVSize = ((uvCount & 0xF) << 4) | (colorType & 0xF);
+            poly.boneType = weightType;
+            poly.normalType = normalType;
+            poly.colorType = colorType;
+            poly.uvType = uvType;
+            poly.uvCount = uvCount;
+            poly.strip = faceType;
 
             Close();
         }


### PR DESCRIPTION
I have updated the PolygonFormatEditor menu to add new features, improve existing ones, and clean up the code.
- Reordered field options to be more logical. Options are ordered by the size of the data type they correspond to, which also happens to prioritise the options most commonly used in Smash.
- Added a new field for vertex color type. (Replaces a checkbox.)
- Added a new field for UV type.
- Added a new field for face type.
  - Added conversions between triangles and triangle strips. The conversion to triangle strips currently doesn't have an algorithm to make proper strips, so it simply converts the triangles directly into individual strips.